### PR TITLE
ci(dco): skip merge commits in Signed-off-by check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
               echo "Missing Signed-off-by trailer: $commit"
               missing=1
             fi
-          done < <(git rev-list "origin/${BASE_REF}..HEAD")
+          done < <(git rev-list --no-merges "origin/${BASE_REF}..HEAD")
 
           if [ "$missing" -ne 0 ]; then
             echo "DCO check failed. Rebase/amend with: git commit --signoff"


### PR DESCRIPTION
## Summary

- Adds `--no-merges` to the `git rev-list` call in the DCO check step.

## Root cause

GitHub Actions checks out `refs/pull/N/merge` as `HEAD` when running PR checks. That ref is an auto-generated merge commit with the message `Merge <head-sha> into <base-sha>` — no `Signed-off-by` trailer. The existing `git rev-list origin/${BASE_REF}..HEAD` range includes this commit, causing a false-positive DCO failure on every PR even when all authored commits are properly signed off.

## Fix

`--no-merges` excludes merge commits from the rev-list walk, so only real authored commits are checked.

## Testing

Verified locally that `git rev-list --no-merges origin/main..HEAD` produces only the expected authored commits and excludes the virtual merge commit.