### PR TITLE
ci: rename HOMEBREW_APP_* → RELEASE_BOT_* in release workflows

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,8 +17,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.HOMEBREW_APP_ID }}
-          private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - uses: skaphos/actions/release-pr@v1.0.0

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,8 +17,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.HOMEBREW_APP_ID }}
-          private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - uses: skaphos/actions/release-tag@v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.HOMEBREW_APP_ID }}
-          private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: skaphos
           repositories: homebrew-tools
           skip-token-revoke: false


### PR DESCRIPTION
## Summary

These secrets/vars hold the release-bot GitHub App's identity, not anything homebrew-specific. The app mints installation tokens for:
- `release-pr.yml` + `release-tag.yml` — release-please flow
- `release.yml` — passed to goreleaser as `HOMEBREW_TAP_GITHUB_TOKEN` for the homebrew formula publish

With berth joining the family, the org-level migration to `RELEASE_BOT_*` gives a single source of truth across repos.

## Renames

- `vars.HOMEBREW_APP_ID` → `vars.RELEASE_BOT_APP_ID`
- `secrets.HOMEBREW_APP_PRIVATE_KEY` → `secrets.RELEASE_BOT_PRIVATE_KEY`

## Untouched (correctly named)

- `HOMEBREW_TOKEN` env var in `release.yml` — local variable holding the minted token used to probe + write the `homebrew-tools` repo.
- `HOMEBREW_TAP_GITHUB_TOKEN` env var — goreleaser's standard input name for the homebrew tap auth; renaming would break goreleaser.

## Prerequisite

Org-level `RELEASE_BOT_APP_ID` (variable) and `RELEASE_BOT_PRIVATE_KEY` (secret) already exist with repokeeper in the access list — configured ahead of this PR.

## Test plan

- [ ] CI green (DCO, lint, test, etc.)
- [ ] On merge: next push to main runs `Release PR` → token mint succeeds → release PR opens/updates
- [ ] Once a release PR merges: `Release Tag` mints token → pushes the `vX.Y.Z` tag
- [ ] On tag push: `Release` mints token → goreleaser publishes images + homebrew formula