### PR TITLE
ci(release-tag): scope trigger to PRs against main

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -3,6 +3,7 @@ name: Release Tag
 on:
   pull_request:
     types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -10,7 +11,12 @@ permissions:
 jobs:
   release-tag:
     name: Push Release Tag
-    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'release-pr')
+    # Guard against accidental tag pushes: only fire for merged PRs
+    # against main that carry the release-please label.
+    if: >-
+      github.event.pull_request.merged &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'release-pr')
     runs-on: ubuntu-latest
     steps:
       - name: Mint release bot token

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,7 +12,7 @@ jobs:
   release-tag:
     name: Push Release Tag
     # Guard against accidental tag pushes: only fire for merged PRs
-    # against main that carry the release-please label.
+    # against main that carry the release-pr label.
     if: >-
       github.event.pull_request.merged &&
       github.event.pull_request.base.ref == 'main' &&


### PR DESCRIPTION
## Summary

`release-tag.yml`'s `pull_request: types: [closed]` trigger fires on every closed PR in the repo regardless of base branch. Without an explicit branch guard, a PR opened against any branch and merged with the `release-pr` label would mint a tag — even if the merge isn't into main.

Add `on.pull_request.branches: [main]` and a defense-in-depth `if: github.event.pull_request.base.ref == 'main'` so the job only fires for the intended release flow.

Caught by Copilot reviewing the analogous workflow in `skaphos/berth`. Mirrors the same fix landing in berth PR #7 and fathom PR #34.

## Test plan

- [x] YAML still parses (helm/yq sanity)
- [ ] Verified on next release-please PR merge (no behavior change expected for the happy path; the new guard only blocks the off-main case)