### PR TITLE
fix(release): resolve homebrew cask audit failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           fi
       - uses: goreleaser/goreleaser-action@v7
         with:
-          version: v2.15.2
+          version: v2.15.4
           args: ${{ steps.goreleaser_args.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,7 +94,7 @@ homebrew_casks:
       - repokeeper
     custom_block: |
       postflight do
-        on_macos do
+        if OS.mac?
           system_command "/usr/bin/xattr",
                          args: ["-dr", "com.apple.quarantine", "#{staged_path}/repokeeper"]
         end


### PR DESCRIPTION
## Summary

Follow-up to #195. Resolves the remaining `brew audit` offenses on the generated `skaphos/homebrew-tools/repokeeper` cask.

- Replace `on_macos do/end` with `if OS.mac?` inside the postflight `custom_block`. The `on_macos` macro is only valid at cask top-level; inside `postflight` it trips `Cask/OnSystemConditionals`.
- Bump pinned goreleaser `v2.15.2 → v2.15.4` to pick up the stanza-order fix for per-arch cask blocks (`Cask/StanzaOrder`) and the trailing-blank-line fix inside `custom_block` (`Layout/EmptyLinesAroundBlockBody`).

Together these clear all 17 offenses reported by `brew audit`.

## Verification

- `goreleaser check` passes on `.goreleaser.yaml`
- YAML parses for both changed files

Closes SKA-255