### PR TITLE
ci: add least-privilege permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for all jobs. Every job only reads the repo
+# (checkout, build, test, lint); artifact uploads and step summaries do not
+# require token scopes. Grant narrower per-job permissions if a job ever needs
+# more (e.g. contents: write for releases).
+permissions:
+  contents: read
+
 jobs:
   dco:
     name: DCO


### PR DESCRIPTION
## Summary

Resolves all **9 open CodeQL `actions/missing-workflow-permissions` alerts** (#1–#9), one per job in `.github/workflows/ci.yml`. The workflow declared no `permissions:` block, so every job inherited the repository-default `GITHUB_TOKEN` scope.

Adds a single **workflow-level** least-privilege block:

```yaml
permissions:
  contents: read
```

## Why `contents: read` is sufficient for every job

| Job | Needs |
|---|---|
| dco | checkout + `git fetch` → read |
| reuse | checkout + pip → read |
| lint / test / integration / quality / perf / build | checkout + go → read |
| upload-artifact steps (test, perf) | Actions artifact API — **not** governed by token scopes |
| summary | writes `$GITHUB_STEP_SUMMARY` (a file) — no token scope |

No job pushes commits, creates releases, or writes to the API, so no `write` scope is required. This brings `ci.yml` in line with the explicit `permissions:` blocks already declared in `release.yml`, `release-pr.yml`, and `release-tag.yml`.

## Verification

- `ci.yml` parses as valid YAML; `permissions` resolves to `{contents: read}`.
- CodeQL re-scans on this PR; the 9 alerts should close automatically once it runs against the updated workflow.