### PR TITLE
feat(install): ship Claude permissions snippet for read-only MCP tools (SKA-254)

### DIFF
--- a/cmd/repokeeper/install.go
+++ b/cmd/repokeeper/install.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/skaphos/repokeeper/internal/mcpinstall"
+	"github.com/skaphos/repokeeper/internal/mcpserver"
 	"github.com/spf13/cobra"
 )
 
@@ -148,6 +149,11 @@ func printManualSnippets(w io.Writer, target string, desired mcpinstall.Entry) e
 		if _, err := fmt.Fprintf(w, "# %s\n%s", name, snippet); err != nil {
 			return err
 		}
+		if name == "claude" {
+			if err := printClaudePermissionsBlock(w); err != nil {
+				return err
+			}
+		}
 		if i < len(names)-1 {
 			if _, err := fmt.Fprintln(w); err != nil {
 				return err
@@ -155,6 +161,28 @@ func printManualSnippets(w io.Writer, target string, desired mcpinstall.Entry) e
 		}
 	}
 	return nil
+}
+
+// printClaudePermissionsBlock emits a commented, paste-ready
+// permissions.allow snippet for ~/.claude/settings.json that auto-approves
+// RepoKeeper's read-only tools. Mutation tools are deliberately excluded so
+// they keep prompting (ADR-0001). The tool list is derived from the live MCP
+// server annotations, so it cannot drift from what the server registers.
+func printClaudePermissionsBlock(w io.Writer) error {
+	permissions, err := mcpinstall.ClaudePermissionsSnippet(mcpserver.ReadOnlyToolNames())
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(w,
+		"\n# claude — recommended ~/.claude/settings.json permissions\n"+
+			"# Auto-approves RepoKeeper's read-only tools. Mutation tools (scan_workspace,\n"+
+			"# execute_sync, set_labels, add_repository, remove_repository) are omitted on\n"+
+			"# purpose so they keep prompting.\n",
+	); err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, permissions)
+	return err
 }
 
 func desiredInstallEntry(override string) (mcpinstall.Entry, error) {

--- a/cmd/repokeeper/install_permissions_test.go
+++ b/cmd/repokeeper/install_permissions_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+package repokeeper
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/skaphos/repokeeper/internal/mcpinstall"
+	"github.com/skaphos/repokeeper/internal/mcpserver"
+)
+
+// expectedAllowList is the prefixed permissions.allow set derived from the live
+// server annotations — the single source of truth both the docs and the manual
+// output must match.
+func expectedAllowList() []string {
+	names := mcpserver.ReadOnlyToolNames()
+	allow := make([]string, 0, len(names))
+	for _, n := range names {
+		allow = append(allow, mcpinstall.ClaudePermissionToolName(n))
+	}
+	sort.Strings(allow)
+	return allow
+}
+
+// mutationTools are the tools that must never appear in permissions.allow, so
+// they keep prompting (ADR-0001).
+var mutationTools = []string{
+	"scan_workspace",
+	"execute_sync",
+	"set_labels",
+	"add_repository",
+	"remove_repository",
+}
+
+// TestInstallManualClaudeEmitsPermissionsBlock asserts `install --manual=claude`
+// prints a permissions.allow block listing exactly the read-only tools and none
+// of the mutation tools.
+func TestInstallManualClaudeEmitsPermissionsBlock(t *testing.T) {
+	withInstallEnv(t)
+	stdout, _, err := runInstallWithFlags(t, map[string]string{
+		"manual":  "claude",
+		"command": "/fake/repokeeper",
+	})
+	if err != nil {
+		t.Fatalf("install --manual=claude: %v", err)
+	}
+	out := stdout.String()
+
+	if !strings.Contains(out, "\"permissions\"") || !strings.Contains(out, "\"allow\"") {
+		t.Fatalf("expected a permissions.allow block, got: %q", out)
+	}
+	for _, want := range expectedAllowList() {
+		if !strings.Contains(out, "\""+want+"\"") {
+			t.Errorf("manual output missing read-only permission %q", want)
+		}
+	}
+	for _, m := range mutationTools {
+		perm := mcpinstall.ClaudePermissionToolName(m)
+		if strings.Contains(out, "\""+perm+"\"") {
+			t.Errorf("manual output must not allow-list mutation tool %q", perm)
+		}
+	}
+}
+
+// TestInstallManualSingleTargetExcludesClaudePermissions confirms the
+// permissions block is Claude-specific: a non-claude target must not emit it.
+func TestInstallManualSingleTargetExcludesClaudePermissions(t *testing.T) {
+	withInstallEnv(t)
+	stdout, _, err := runInstallWithFlags(t, map[string]string{
+		"manual":  "codex",
+		"command": "/fake/repokeeper",
+	})
+	if err != nil {
+		t.Fatalf("install --manual=codex: %v", err)
+	}
+	if strings.Contains(stdout.String(), "\"permissions\"") {
+		t.Errorf("codex manual output should not contain a Claude permissions block")
+	}
+}
+
+// TestDocsPermissionsSnippetMatchesReadOnlyTools is the drift guard: the
+// allow-list hardcoded in docs/mcp-setup.md must equal the read-only tool set
+// currently registered. Adding/removing a tool without updating the docs fails.
+func TestDocsPermissionsSnippetMatchesReadOnlyTools(t *testing.T) {
+	const docPath = "../../docs/mcp-setup.md"
+	data, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	content := string(data)
+
+	marker := "## Recommended Claude Code permissions"
+	idx := strings.Index(content, marker)
+	if idx < 0 {
+		t.Fatalf("docs missing %q section", marker)
+	}
+	section := content[idx:]
+
+	start := strings.Index(section, "```json")
+	if start < 0 {
+		t.Fatal("docs permissions section has no ```json block")
+	}
+	start += len("```json")
+	end := strings.Index(section[start:], "```")
+	if end < 0 {
+		t.Fatal("docs permissions json block is not closed")
+	}
+	jsonText := section[start : start+end]
+
+	var doc struct {
+		Permissions struct {
+			Allow []string `json:"allow"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal([]byte(jsonText), &doc); err != nil {
+		t.Fatalf("docs permissions snippet is not valid JSON: %v\n%s", err, jsonText)
+	}
+
+	got := append([]string(nil), doc.Permissions.Allow...)
+	sort.Strings(got)
+	want := expectedAllowList()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("docs/mcp-setup.md permissions.allow drifted from registered read-only tools\n got: %v\nwant: %v", got, want)
+	}
+}

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -158,6 +158,34 @@ Examples:
 | `repokeeper://repo/{repo_id}` | Single registry entry |
 | `repokeeper://repo/{repo_id}/metadata` | Repo-local metadata |
 
+## Recommended Claude Code permissions
+
+Claude Code prompts for confirmation on every MCP tool call by default. To skip the prompt for RepoKeeper's safe, read-only tools — while keeping the prompt for anything that changes state — add the following to your Claude Code settings (`~/.claude/settings.json` for user scope, or `.claude/settings.json` for project scope):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__repokeeper__build_workspace_inventory",
+      "mcp__repokeeper__get_authoritative_paths",
+      "mcp__repokeeper__get_related_repositories",
+      "mcp__repokeeper__get_repo_metadata",
+      "mcp__repokeeper__get_repository_context",
+      "mcp__repokeeper__get_workspace_config",
+      "mcp__repokeeper__list_repositories",
+      "mcp__repokeeper__plan_sync",
+      "mcp__repokeeper__select_repositories"
+    ]
+  }
+}
+```
+
+> **Warning:** Pasting this grants Claude Code blanket auto-approval for the listed tools — it will run them without asking. Every entry is read-only or dry-run (`plan_sync`), so they cannot change your repositories or registry.
+
+The five mutation tools — `scan_workspace`, `execute_sync`, `set_labels`, `add_repository`, `remove_repository` — are deliberately **not** listed, so they keep prompting on every call (RepoKeeper's read-and-plan safety model, [ADR-0001](adr/0001-mcp-server.md)). Avoid the broad `"mcp__repokeeper__*"` wildcard: it would also auto-approve those mutations.
+
+`repokeeper install --manual=claude` prints this same block (derived from the live server's tool annotations) alongside the registration snippet.
+
 ## Runtimes without a RepoKeeper adapter
 
 `repokeeper install` only writes config for runtimes it has an adapter for (Claude Code, Codex, OpenCode, Grok). For other MCP-capable runtimes, edit the runtime's config file by hand using the shape documented below. `repokeeper install --manual` prints the supported runtime snippets to stdout as a convenience, but the sections here are authoritative for each runtime.

--- a/internal/mcpinstall/snippet.go
+++ b/internal/mcpinstall/snippet.go
@@ -4,6 +4,7 @@ package mcpinstall
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
@@ -44,6 +45,30 @@ func Snippet(runtime string, e Entry) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown runtime: %q", runtime)
 	}
+}
+
+// ClaudePermissionToolName returns the identifier Claude Code matches in
+// permissions.allow for a repokeeper MCP tool, i.e. mcp__<server>__<tool>.
+func ClaudePermissionToolName(tool string) string {
+	return "mcp__" + repokeeperKey + "__" + tool
+}
+
+// ClaudePermissionsSnippet renders a ~/.claude/settings.json fragment that
+// allow-lists the given tools under permissions.allow. Callers pass the
+// read-only tool set only; mutation tools are intentionally omitted so they
+// keep prompting (ADR-0001's read-and-plan safety model). Entries are sorted
+// for deterministic output.
+func ClaudePermissionsSnippet(toolNames []string) (string, error) {
+	allow := make([]string, 0, len(toolNames))
+	for _, t := range toolNames {
+		allow = append(allow, ClaudePermissionToolName(t))
+	}
+	sort.Strings(allow)
+	return renderJSON(map[string]any{
+		"permissions": map[string]any{
+			"allow": allow,
+		},
+	})
 }
 
 func renderJSON(doc map[string]any) (string, error) {

--- a/internal/mcpinstall/snippet_test.go
+++ b/internal/mcpinstall/snippet_test.go
@@ -16,6 +16,43 @@ func TestSnippetUnknownRuntime(t *testing.T) {
 	}
 }
 
+func TestClaudePermissionToolName(t *testing.T) {
+	t.Parallel()
+	got := ClaudePermissionToolName("list_repositories")
+	if want := "mcp__repokeeper__list_repositories"; got != want {
+		t.Fatalf("ClaudePermissionToolName = %q, want %q", got, want)
+	}
+}
+
+func TestClaudePermissionsSnippet(t *testing.T) {
+	t.Parallel()
+	// Pass names out of order to prove the output is sorted and prefixed.
+	got, err := ClaudePermissionsSnippet([]string{"plan_sync", "list_repositories"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Permissions struct {
+			Allow []string `json:"allow"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal([]byte(got), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, got)
+	}
+	want := []string{"mcp__repokeeper__list_repositories", "mcp__repokeeper__plan_sync"}
+	if len(doc.Permissions.Allow) != len(want) {
+		t.Fatalf("allow = %v, want %v", doc.Permissions.Allow, want)
+	}
+	for i, w := range want {
+		if doc.Permissions.Allow[i] != w {
+			t.Fatalf("allow[%d] = %q, want %q (full: %v)", i, doc.Permissions.Allow[i], w, doc.Permissions.Allow)
+		}
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("snippet should end with newline: %q", got)
+	}
+}
+
 func TestSnippetClaudeIsValidJSON(t *testing.T) {
 	t.Parallel()
 	got, err := Snippet("claude", Entry{Command: "/bin/repokeeper", Args: []string{"mcp"}})

--- a/internal/mcpserver/readonly_tools_test.go
+++ b/internal/mcpserver/readonly_tools_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+package mcpserver_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/skaphos/repokeeper/internal/mcpserver"
+)
+
+// TestReadOnlyToolNames pins the read-only tool set derived from the live
+// ReadOnlyHint annotations. If a tool is added, removed, or its annotation
+// flipped, this fails — which is the signal to update the shipped
+// permissions snippet (docs/mcp-setup.md and `install --manual`).
+func TestReadOnlyToolNames(t *testing.T) {
+	want := []string{
+		"build_workspace_inventory",
+		"get_authoritative_paths",
+		"get_related_repositories",
+		"get_repo_metadata",
+		"get_repository_context",
+		"get_workspace_config",
+		"list_repositories",
+		"plan_sync",
+		"select_repositories",
+	}
+	got := mcpserver.ReadOnlyToolNames()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReadOnlyToolNames() mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestReadOnlyToolNamesExcludesMutationTools guards the safety boundary: the
+// mutation tools must never appear in the read-only set, or the shipped
+// permissions.allow snippet would auto-approve them (the opposite of ADR-0001).
+func TestReadOnlyToolNamesExcludesMutationTools(t *testing.T) {
+	mutation := []string{
+		"scan_workspace",
+		"execute_sync",
+		"set_labels",
+		"add_repository",
+		"remove_repository",
+	}
+	got := mcpserver.ReadOnlyToolNames()
+	inSet := make(map[string]struct{}, len(got))
+	for _, n := range got {
+		inSet[n] = struct{}{}
+	}
+	for _, m := range mutation {
+		if _, ok := inSet[m]; ok {
+			t.Errorf("mutation tool %q must not be in the read-only set", m)
+		}
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -2,6 +2,8 @@
 package mcpserver
 
 import (
+	"sort"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -42,6 +44,23 @@ func New(eng EngineAPI, cfgPath, version string, logger obs.Logger) *MCPServer {
 
 // Inner returns the underlying mcp-go server for transport binding.
 func (s *MCPServer) Inner() *server.MCPServer { return s.inner }
+
+// ReadOnlyToolNames returns the sorted names of every registered tool whose
+// ReadOnlyHint annotation is true. It derives the set from the live registered
+// tools (registerTools is the single source of truth), so it can never drift
+// from what the server actually exposes. Tool registration does not touch the
+// engine, so a nil engine is safe for enumeration here.
+func ReadOnlyToolNames() []string {
+	s := New(nil, "", "", nil)
+	names := make([]string, 0)
+	for name, st := range s.inner.ListTools() {
+		if hint := st.Tool.Annotations.ReadOnlyHint; hint != nil && *hint {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
 
 func (s *MCPServer) registerTools() {
 	s.inner.AddTools(


### PR DESCRIPTION
## Summary

Closes SKA-254. Claude Code prompts on every MCP tool call by default. Users who silence that with a broad `"mcp__repokeeper__*"` wildcard also auto-approve the **mutation** tools — the opposite of ADR-0001's read-and-plan safety model. This ships a recommended `permissions.allow` snippet covering **only** the read-only surface.

The server-side `ReadOnlyHint` annotations already exist, so the snippet is **derived** from them rather than hand-maintained — making the docs/manual list a derivation of the registered tool set, as the ticket anticipated.

## Changes

- **`mcpserver.ReadOnlyToolNames()`** — sorted names of registered tools whose `ReadOnlyHint` is true, enumerated from the actual registered tool set (`registerTools` stays the single source of truth; no second list).
- **`mcpinstall.ClaudePermissionsSnippet` / `ClaudePermissionToolName`** — render a `settings.json` `permissions.allow` block, prefixing each tool with `mcp__repokeeper__`.
- **`install --manual=claude`** (and `=all`) print the permissions block after the registration snippet, with a comment naming the excluded mutation tools.
- **`docs/mcp-setup.md`** — new "Recommended Claude Code permissions" section: the snippet, an auto-approval warning, and the rationale for excluding mutation tools.

The 9 read-only tools are allow-listed; the 5 mutation tools (`scan_workspace`, `execute_sync`, `set_labels`, `add_repository`, `remove_repository`) are intentionally omitted so they keep prompting.

## Drift guards (acceptance criterion #3)

- `mcpserver`: pins the read-only set and asserts mutation tools are excluded.
- `cmd/repokeeper`: asserts `install --manual=claude` lists exactly the read-only permissions and none of the mutations; a non-claude target emits no permissions block.
- Docs test: parses the `permissions.allow` array out of `docs/mcp-setup.md` and fails if it diverges from the registered read-only tools — so adding/removing a tool without updating the docs breaks the build.

## Out of scope (deferred per ticket)

- `install --claude` auto-writing the snippet (crosses from server registration into client policy — separate trust surface).
- Cursor / Windsurf equivalents.

## Verification

- `go build/vet ./...`, `go test ./...` — pass
- `golangci-lint` 0 issues · `staticcheck` clean · `govulncheck` no vulns · `reuse lint` compliant

### Sample `install --manual=claude` output

```
# claude
{ "mcpServers": { "repokeeper": { "command": "...", "args": ["mcp"] } } }

# claude — recommended ~/.claude/settings.json permissions
# Auto-approves RepoKeeper's read-only tools. Mutation tools (...) are omitted on purpose so they keep prompting.
{ "permissions": { "allow": [ "mcp__repokeeper__build_workspace_inventory", ... "mcp__repokeeper__select_repositories" ] } }
```