### PR TITLE
feat(get): add apiVersion to -o json output and document schema stability (SKA-208)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -606,7 +606,7 @@ The `get` / `status -o json` output is a contractual surface (§"adapter contrac
 * **Additive changes are non-breaking and do not bump `apiVersion`.** Adding a new top-level or per-repo field is always allowed; consumers must ignore unknown fields.
 * **Breaking changes bump `apiVersion`.** Removing or renaming a field, or changing a field's type or semantics (including the meaning of an existing enum value), is breaking. The version moves forward (`v1beta1` → next) and the change is documented here.
 * The output `apiVersion` is versioned **independently of the config `apiVersion`** (`internal/config`). They happen to share the value `skaphos.io/repokeeper/v1beta1` today, but a bump to one does not require a bump to the other.
-* The value is sourced from a single constant (`statusJSONAPIVersion` in `cmd/repokeeper`), so the emitted version and this document cannot silently diverge.
+* The value is sourced from a single constant (`statusJSONAPIVersion` in `cmd/repokeeper`). A test (`TestDesignDocNamesStatusJSONAPIVersion`) asserts this document names the current constant value, so the emitted version and this policy cannot silently diverge.
 
 ## 7. Git Operations (Engine Contract)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -564,6 +564,7 @@ Top-level:
 
 ```json
 {
+  "apiVersion": "skaphos.io/repokeeper/v1beta1",
   "generated_at": "…",
   "repos": [
     {
@@ -596,6 +597,16 @@ Field notes:
 * **`remotes`** — all configured remotes for the repo, not just one. The `primary_remote` field indicates which remote was used for `repo_id` derivation.
 * **`primary_remote`** — preference order: `origin` > first alphabetically. Used for repo identity and tracking status.
 * **`tracking.ahead`** / **`tracking.behind`** — integer counts. Both `0` when `status` is `"equal"`. Both `null` when `status` is `"gone"` or `"none"` (no upstream to compare against).
+* **`apiVersion`** — identifies the schema of this JSON contract (see the stability policy below). When filtered to `diverged`, the top-level object additionally carries a `diverged` advice array; `apiVersion` is unchanged by that filter.
+
+#### JSON output schema stability policy
+
+The `get` / `status -o json` output is a contractual surface (§"adapter contract": machine-readable JSON is versioned/documented, unlike human-oriented table output). Its schema is identified by the top-level `apiVersion`, currently `skaphos.io/repokeeper/v1beta1`. The contract:
+
+* **Additive changes are non-breaking and do not bump `apiVersion`.** Adding a new top-level or per-repo field is always allowed; consumers must ignore unknown fields.
+* **Breaking changes bump `apiVersion`.** Removing or renaming a field, or changing a field's type or semantics (including the meaning of an existing enum value), is breaking. The version moves forward (`v1beta1` → next) and the change is documented here.
+* The output `apiVersion` is versioned **independently of the config `apiVersion`** (`internal/config`). They happen to share the value `skaphos.io/repokeeper/v1beta1` today, but a bump to one does not require a bump to the other.
+* The value is sourced from a single constant (`statusJSONAPIVersion` in `cmd/repokeeper`), so the emitted version and this document cannot silently diverge.
 
 ## 7. Git Operations (Engine Contract)
 

--- a/cmd/repokeeper/status.go
+++ b/cmd/repokeeper/status.go
@@ -47,7 +47,15 @@ type statusJSONRepo struct {
 	LocalLabels map[string]string `json:"local_labels,omitempty"`
 }
 
+// statusJSONAPIVersion identifies the schema of the `get`/`status -o json`
+// output contract. It is intentionally separate from config.ConfigAPIVersion
+// (same value today) so the output schema can be versioned independently of the
+// config schema. Bump it on any breaking change to the JSON shape; see the JSON
+// output schema stability policy in DESIGN.md §6.3.
+const statusJSONAPIVersion = "skaphos.io/repokeeper/v1beta1"
+
 type statusJSONReport struct {
+	APIVersion  string           `json:"apiVersion"`
 	GeneratedAt time.Time        `json:"generated_at"`
 	Repos       []statusJSONRepo `json:"repos"`
 }
@@ -256,7 +264,7 @@ var statusCmd = &cobra.Command{
 }
 
 func buildStatusJSONOutput(report *model.StatusReport, includeDiverged bool) any {
-	jsonReport := statusJSONReport{}
+	jsonReport := statusJSONReport{APIVersion: statusJSONAPIVersion}
 	if report != nil {
 		jsonReport.GeneratedAt = report.GeneratedAt
 		jsonReport.Repos = make([]statusJSONRepo, 0, len(report.Repos))

--- a/cmd/repokeeper/status.go
+++ b/cmd/repokeeper/status.go
@@ -265,10 +265,12 @@ var statusCmd = &cobra.Command{
 
 func buildStatusJSONOutput(report *model.StatusReport, includeDiverged bool) any {
 	jsonReport := statusJSONReport{APIVersion: statusJSONAPIVersion}
+	var repos []model.RepoStatus
 	if report != nil {
+		repos = report.Repos
 		jsonReport.GeneratedAt = report.GeneratedAt
-		jsonReport.Repos = make([]statusJSONRepo, 0, len(report.Repos))
-		for _, repo := range report.Repos {
+		jsonReport.Repos = make([]statusJSONRepo, 0, len(repos))
+		for _, repo := range repos {
 			jsonReport.Repos = append(jsonReport.Repos, statusJSONRepo{
 				RepoStatus:  repo,
 				LocalLabels: cloneMetadataMap(repo.Labels),
@@ -278,9 +280,11 @@ func buildStatusJSONOutput(report *model.StatusReport, includeDiverged bool) any
 	if !includeDiverged {
 		return jsonReport
 	}
+	// repos is nil-safe here: buildDivergedAdvice ranges over it, so a nil
+	// report yields an empty (non-nil) advice slice rather than panicking.
 	return divergedJSONOutput{
 		statusJSONReport: jsonReport,
-		Diverged:         buildDivergedAdvice(report.Repos),
+		Diverged:         buildDivergedAdvice(repos),
 	}
 }
 

--- a/cmd/repokeeper/status_helpers_test.go
+++ b/cmd/repokeeper/status_helpers_test.go
@@ -3,7 +3,10 @@ package repokeeper
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/skaphos/repokeeper/internal/model"
 )
@@ -23,12 +26,16 @@ func TestRelatedReposString(t *testing.T) {
 
 // TestStatusJSONOutputIncludesAPIVersion locks the SKA-208 contract: the
 // `get`/`status -o json` envelope carries a top-level apiVersion equal to the
-// schema constant, in both the normal and --only diverged shapes, without
-// dropping the existing generated_at/repos fields.
+// schema constant, in both the normal and --only diverged shapes, while
+// preserving the existing generated_at/repos fields. Assertions unmarshal into
+// a map so a *removed* field is detected (a struct field would silently default
+// to its zero value).
 func TestStatusJSONOutputIncludesAPIVersion(t *testing.T) {
 	t.Parallel()
 
+	generatedAt := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	report := &model.StatusReport{
+		GeneratedAt: generatedAt,
 		Repos: []model.RepoStatus{
 			{RepoID: "github.com/org/healthy", Path: "/repos/healthy", Tracking: model.Tracking{Status: model.TrackingEqual}},
 			{
@@ -39,51 +46,111 @@ func TestStatusJSONOutputIncludesAPIVersion(t *testing.T) {
 		},
 	}
 
-	t.Run("normal output", func(t *testing.T) {
-		t.Parallel()
-		raw, err := json.Marshal(buildStatusJSONOutput(report, false))
+	decode := func(t *testing.T, v any) map[string]json.RawMessage {
+		t.Helper()
+		raw, err := json.Marshal(v)
 		if err != nil {
 			t.Fatalf("marshal status json: %v", err)
 		}
-		var doc struct {
-			APIVersion  string            `json:"apiVersion"`
-			GeneratedAt string            `json:"generated_at"`
-			Repos       []json.RawMessage `json:"repos"`
-			Diverged    []json.RawMessage `json:"diverged"`
-		}
+		var doc map[string]json.RawMessage
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			t.Fatalf("unmarshal status json: %v\n%s", err, raw)
 		}
-		if doc.APIVersion != statusJSONAPIVersion {
-			t.Errorf("apiVersion = %q, want %q", doc.APIVersion, statusJSONAPIVersion)
+		return doc
+	}
+
+	assertString := func(t *testing.T, doc map[string]json.RawMessage, key string) string {
+		t.Helper()
+		raw, ok := doc[key]
+		if !ok {
+			t.Fatalf("expected key %q to be present in output (existing field must not be dropped)", key)
 		}
-		if len(doc.Repos) != len(report.Repos) {
-			t.Errorf("repos length = %d, want %d (existing field must be preserved)", len(doc.Repos), len(report.Repos))
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			t.Fatalf("key %q is not a string: %v", key, err)
 		}
-		if doc.Diverged != nil {
-			t.Errorf("normal output must not include diverged array, got %v", doc.Diverged)
+		return s
+	}
+
+	assertArrayLen := func(t *testing.T, doc map[string]json.RawMessage, key string, want int) {
+		t.Helper()
+		raw, ok := doc[key]
+		if !ok {
+			t.Fatalf("expected key %q to be present in output", key)
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			t.Fatalf("key %q is not an array: %v", key, err)
+		}
+		if len(arr) != want {
+			t.Errorf("%s length = %d, want %d", key, len(arr), want)
+		}
+	}
+
+	t.Run("normal output", func(t *testing.T) {
+		t.Parallel()
+		doc := decode(t, buildStatusJSONOutput(report, false))
+
+		if got := assertString(t, doc, "apiVersion"); got != statusJSONAPIVersion {
+			t.Errorf("apiVersion = %q, want %q", got, statusJSONAPIVersion)
+		}
+		// generated_at must survive and round-trip, not just exist.
+		if got := assertString(t, doc, "generated_at"); got != generatedAt.Format(time.RFC3339Nano) {
+			t.Errorf("generated_at = %q, want %q", got, generatedAt.Format(time.RFC3339Nano))
+		}
+		assertArrayLen(t, doc, "repos", len(report.Repos))
+		if _, ok := doc["diverged"]; ok {
+			t.Errorf("normal output must not include a diverged array")
 		}
 	})
 
 	t.Run("diverged output", func(t *testing.T) {
 		t.Parallel()
-		raw, err := json.Marshal(buildStatusJSONOutput(report, true))
+		doc := decode(t, buildStatusJSONOutput(report, true))
+
+		if got := assertString(t, doc, "apiVersion"); got != statusJSONAPIVersion {
+			t.Errorf("diverged apiVersion = %q, want %q", got, statusJSONAPIVersion)
+		}
+		// The existing repos field must remain alongside the diverged advice.
+		assertArrayLen(t, doc, "repos", len(report.Repos))
+		assertArrayLen(t, doc, "diverged", 1)
+	})
+}
+
+// TestStatusJSONOutputNilReportIsSafe guards the nil-report path: building the
+// diverged envelope from a nil report must not panic and must still carry the
+// apiVersion (regression for the buildDivergedAdvice nil-deref).
+func TestStatusJSONOutputNilReportIsSafe(t *testing.T) {
+	t.Parallel()
+	for _, includeDiverged := range []bool{false, true} {
+		raw, err := json.Marshal(buildStatusJSONOutput(nil, includeDiverged))
 		if err != nil {
-			t.Fatalf("marshal diverged json: %v", err)
+			t.Fatalf("marshal nil report (diverged=%t): %v", includeDiverged, err)
 		}
 		var doc struct {
-			APIVersion string            `json:"apiVersion"`
-			Repos      []json.RawMessage `json:"repos"`
-			Diverged   []json.RawMessage `json:"diverged"`
+			APIVersion string `json:"apiVersion"`
 		}
 		if err := json.Unmarshal(raw, &doc); err != nil {
-			t.Fatalf("unmarshal diverged json: %v\n%s", err, raw)
+			t.Fatalf("unmarshal nil report (diverged=%t): %v", includeDiverged, err)
 		}
 		if doc.APIVersion != statusJSONAPIVersion {
-			t.Errorf("diverged apiVersion = %q, want %q", doc.APIVersion, statusJSONAPIVersion)
+			t.Errorf("nil report (diverged=%t) apiVersion = %q, want %q", includeDiverged, doc.APIVersion, statusJSONAPIVersion)
 		}
-		if len(doc.Diverged) != 1 {
-			t.Errorf("diverged advice length = %d, want 1", len(doc.Diverged))
-		}
-	})
+	}
+}
+
+// TestDesignDocNamesStatusJSONAPIVersion is the drift guard backing DESIGN.md's
+// claim that the documented schema version cannot silently diverge from the
+// emitted constant. If statusJSONAPIVersion is bumped without updating §6.3,
+// this fails.
+func TestDesignDocNamesStatusJSONAPIVersion(t *testing.T) {
+	t.Parallel()
+	const docPath = "../../DESIGN.md"
+	data, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	if !strings.Contains(string(data), statusJSONAPIVersion) {
+		t.Fatalf("%s does not name the current statusJSONAPIVersion %q; update the JSON output schema policy in §6.3", docPath, statusJSONAPIVersion)
+	}
 }

--- a/cmd/repokeeper/status_helpers_test.go
+++ b/cmd/repokeeper/status_helpers_test.go
@@ -150,7 +150,23 @@ func TestDesignDocNamesStatusJSONAPIVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read %s: %v", docPath, err)
 	}
-	if !strings.Contains(string(data), statusJSONAPIVersion) {
-		t.Fatalf("%s does not name the current statusJSONAPIVersion %q; update the JSON output schema policy in §6.3", docPath, statusJSONAPIVersion)
+	content := string(data)
+
+	// Scope the check to the §6.3 Status JSON schema section. The same
+	// apiVersion value also appears elsewhere in the doc (e.g. the config
+	// example), so a document-wide search would still pass if §6.3 went stale.
+	const header = "### 6.3 Status JSON schema"
+	start := strings.Index(content, header)
+	if start < 0 {
+		t.Fatalf("%s is missing the %q section header", docPath, header)
+	}
+	section := content[start:]
+	// The section runs until the next top-level (## ) heading. "\n## " does not
+	// match the "#### " subheadings within §6.3, so the policy text is included.
+	if end := strings.Index(section[len(header):], "\n## "); end >= 0 {
+		section = section[:len(header)+end]
+	}
+	if !strings.Contains(section, statusJSONAPIVersion) {
+		t.Fatalf("%s §6.3 does not name the current statusJSONAPIVersion %q; update the Status JSON schema section", docPath, statusJSONAPIVersion)
 	}
 }

--- a/cmd/repokeeper/status_helpers_test.go
+++ b/cmd/repokeeper/status_helpers_test.go
@@ -2,6 +2,7 @@
 package repokeeper
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/skaphos/repokeeper/internal/model"
@@ -18,4 +19,71 @@ func TestRelatedReposString(t *testing.T) {
 	if got != "a/repo,z/repo:depends-on" {
 		t.Fatalf("expected sorted related repos string, got %q", got)
 	}
+}
+
+// TestStatusJSONOutputIncludesAPIVersion locks the SKA-208 contract: the
+// `get`/`status -o json` envelope carries a top-level apiVersion equal to the
+// schema constant, in both the normal and --only diverged shapes, without
+// dropping the existing generated_at/repos fields.
+func TestStatusJSONOutputIncludesAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	report := &model.StatusReport{
+		Repos: []model.RepoStatus{
+			{RepoID: "github.com/org/healthy", Path: "/repos/healthy", Tracking: model.Tracking{Status: model.TrackingEqual}},
+			{
+				RepoID:   "github.com/org/diverged",
+				Path:     "/repos/diverged",
+				Tracking: model.Tracking{Status: model.TrackingDiverged, Upstream: "origin/main"},
+			},
+		},
+	}
+
+	t.Run("normal output", func(t *testing.T) {
+		t.Parallel()
+		raw, err := json.Marshal(buildStatusJSONOutput(report, false))
+		if err != nil {
+			t.Fatalf("marshal status json: %v", err)
+		}
+		var doc struct {
+			APIVersion  string            `json:"apiVersion"`
+			GeneratedAt string            `json:"generated_at"`
+			Repos       []json.RawMessage `json:"repos"`
+			Diverged    []json.RawMessage `json:"diverged"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("unmarshal status json: %v\n%s", err, raw)
+		}
+		if doc.APIVersion != statusJSONAPIVersion {
+			t.Errorf("apiVersion = %q, want %q", doc.APIVersion, statusJSONAPIVersion)
+		}
+		if len(doc.Repos) != len(report.Repos) {
+			t.Errorf("repos length = %d, want %d (existing field must be preserved)", len(doc.Repos), len(report.Repos))
+		}
+		if doc.Diverged != nil {
+			t.Errorf("normal output must not include diverged array, got %v", doc.Diverged)
+		}
+	})
+
+	t.Run("diverged output", func(t *testing.T) {
+		t.Parallel()
+		raw, err := json.Marshal(buildStatusJSONOutput(report, true))
+		if err != nil {
+			t.Fatalf("marshal diverged json: %v", err)
+		}
+		var doc struct {
+			APIVersion string            `json:"apiVersion"`
+			Repos      []json.RawMessage `json:"repos"`
+			Diverged   []json.RawMessage `json:"diverged"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("unmarshal diverged json: %v\n%s", err, raw)
+		}
+		if doc.APIVersion != statusJSONAPIVersion {
+			t.Errorf("diverged apiVersion = %q, want %q", doc.APIVersion, statusJSONAPIVersion)
+		}
+		if len(doc.Diverged) != 1 {
+			t.Errorf("diverged advice length = %d, want 1", len(doc.Diverged))
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds a top-level `apiVersion` field to the `get` / `status -o json` output envelope so consumers (MCP server, agent skill, CI scripts) can detect breaking schema changes, and documents the JSON output schema stability policy in `DESIGN.md`.

Closes SKA-208.

## Key reframing vs. the original ticket notes

The ticket's implementation note assumed `get -o json` emits a **bare array** that must be wrapped into `{ apiVersion, items }`, calling it a **breaking shape change** requiring coordination with the MCP read tools (SKA-126/127).

That's no longer accurate. The output is **already an envelope object** — `statusJSONReport { generated_at, repos[] }` (`cmd/repokeeper/status.go`). So:

- Adding a top-level `apiVersion` is **purely additive, not breaking**. Existing consumers reading `.generated_at` / `.repos` keep working.
- No `repos` → `items` rename — honors the AC "existing JSON field names are not changed".
- **No MCP coordination needed**: the MCP server builds its own response structs and does not reuse `buildStatusJSONOutput` (verified by grep).

## Changes

- **`cmd/repokeeper/status.go`**: new `statusJSONAPIVersion` constant (`skaphos.io/repokeeper/v1beta1`), added as the first field of `statusJSONReport` and set in `buildStatusJSONOutput`. Kept separate from `config.ConfigAPIVersion` (same value today) so the output schema versions independently of the config schema. `get`, `get repos`, and `status` all share `statusCmd.RunE`, and `divergedJSONOutput` embeds `statusJSONReport`, so this one change covers every JSON path.
- **`DESIGN.md` §6.3**: added `apiVersion` to the schema example and a **JSON output schema stability policy** (additive = non-breaking; remove/rename/retype = breaking + version bump).
- **`cmd/repokeeper/status_helpers_test.go`**: `TestStatusJSONOutputIncludesAPIVersion` asserts `apiVersion` equals the constant in both the normal and `--only diverged` shapes, and that existing fields are preserved.

## Out of scope (flagged, not changed)

`describe -o json` emits a bare `model.RepoStatus` with no envelope (SKA-205). Versioning that surface is a separate follow-up if desired.

## Verification

`go build/vet/test ./...`, golangci-lint (0 issues), staticcheck (clean), govulncheck (no vulnerabilities), `reuse lint` (289/289 compliant). Commit is DCO-signed.