### PR TITLE
docs(agents): use Conventional Commit type prefixes for branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,14 @@
 
 ## Commit & Pull Request Guidelines
 - **All changes must be delivered via a pull request. Never commit directly to `main`.**
-- Branch naming: use a prefix that matches the change type:
-  - `feature/<short-description>` — new functionality
-  - `bug/<short-description>` — bug fixes
+- Branch naming: use a Conventional Commit **type** prefix that matches the change, followed by a short description. Never prefix branches with a username or a tracker's auto-suggested name.
+  - `feat/<short-description>` — new functionality
+  - `fix/<short-description>` — bug fixes
   - `chore/<short-description>` — maintenance, deps, tooling
   - `docs/<short-description>` — documentation only
   - `ci/<short-description>` — CI/CD pipeline changes
   - `refactor/<short-description>` — internal restructuring without behaviour change
+  - `test/<short-description>` — test-only changes
 - Keep branches focused: one logical change per PR. Split unrelated concerns into separate PRs.
 - All commits must be signed (global SSH signing via 1Password is configured; do not pass `-S` manually).
 - Use concise, imperative subjects (example: "Add registry staleness check") and include context in the body if needed.


### PR DESCRIPTION
## Summary

Aligns the AGENTS.md branch-naming convention with Conventional Commit **types** and makes the rule unambiguous:

- `feature/` → `feat/`, `bug/` → `fix/` (matches the commit-message convention already used in this repo).
- Adds `test/` for test-only changes.
- Explicitly forbids username- or tracker-suggested branch prefixes (e.g. Linear's auto-suggested `gitBranchName`), so the documented convention matches actual practice.

## Why

The doc previously listed `feature/`/`bug/` while commits use Conventional Commit types (`feat:`, `fix:`, `test:`), and recent feature branches drifted into a username prefix. This closes that gap so the branch prefix and commit type use the same vocabulary.

## Verification

Docs-only change; no code touched. REUSE headers unchanged.