### PR TITLE
feat(reconcile): add stable -o json output with per-repo outcome records (SKA-207)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -608,6 +608,37 @@ The `get` / `status -o json` output is a contractual surface (§"adapter contrac
 * The output `apiVersion` is versioned **independently of the config `apiVersion`** (`internal/config`). They happen to share the value `skaphos.io/repokeeper/v1beta1` today, but a bump to one does not require a bump to the other.
 * The value is sourced from a single constant (`statusJSONAPIVersion` in `cmd/repokeeper`). A test (`TestDesignDocNamesStatusJSONAPIVersion`) asserts this document names the current constant value, so the emitted version and this policy cannot silently diverge.
 
+### 6.4 Sync (reconcile) JSON schema
+
+`reconcile -o json` (alias `sync -o json`) emits a top-level JSON **array** of per-repo result objects — one record per repo in the sync set. Unlike the `get`/`status` collection it is unenveloped, matching the other action commands (`scan`, `repair-upstream`) and the MCP `plan_sync`/`execute_sync` result shape, so CLI and MCP consumers parse identical fields:
+
+```json
+[
+  {
+    "repo_id": "github.com/org/repo",
+    "path": "/home/user/work/org/repo",
+    "action": "git fetch --all --prune",
+    "outcome": "fetched",
+    "ok": true
+  },
+  {
+    "repo_id": "github.com/org/no-upstream",
+    "path": "/home/user/work/org/no-upstream",
+    "action": "",
+    "outcome": "skipped_no_upstream",
+    "ok": true,
+    "error": "skipped-no-upstream"
+  }
+]
+```
+
+Field notes:
+
+* **`outcome`** — the typed `OutcomeKind` (`fetched`, `rebased`, `pushed`, `skipped_no_upstream`, `skipped_missing`, `failed_fetch`, etc.). With `--dry-run` the planned variants are emitted (`planned_fetch`, `planned_push`, `planned_checkout_missing`) and **`planned`** is `true`.
+* **`ok`** — `false` only for operational failures (and `skipped_missing`); intentional skips report `ok: true` with a populated **`error`** reason. Exit-code behavior is independent of this field and unchanged by `-o json`.
+* **`error`** / **`skip_reason`** — omitted when empty.
+* The shape is a stable adapter surface: additive fields are non-breaking; renaming/removing a field or changing a value's meaning is a break. The DTO lives in `cmd/repokeeper` (`syncResultJSON`).
+
 ## 7. Git Operations (Engine Contract)
 
 RepoKeeper shells out to the installed `git` binary for parity with real-world behavior. Use Go git libraries only when the CLI is a poor fit (performance, missing capability, or brittle parsing), and document any such fallback.

--- a/cmd/repokeeper/command_run_test.go
+++ b/cmd/repokeeper/command_run_test.go
@@ -472,8 +472,12 @@ func TestSyncRunEJSONMissingFilter(t *testing.T) {
 	if err := syncCmd.RunE(syncCmd, nil); err != nil {
 		t.Fatalf("sync run failed: %v", err)
 	}
-	if !strings.Contains(out.String(), "\"RepoID\": \"github.com/org/repo-missing\"") {
-		t.Fatalf("expected missing repo in json output, got: %q", out.String())
+	got := out.String()
+	if !strings.Contains(got, "\"repo_id\": \"github.com/org/repo-missing\"") {
+		t.Fatalf("expected missing repo_id in json output, got: %q", got)
+	}
+	if !strings.Contains(got, "\"outcome\": \"skipped_missing\"") {
+		t.Fatalf("expected skipped_missing outcome in json output, got: %q", got)
 	}
 }
 

--- a/cmd/repokeeper/sync.go
+++ b/cmd/repokeeper/sync.go
@@ -247,14 +247,28 @@ type syncResultJSON struct {
 }
 
 func toSyncResultJSON(res engine.SyncResult) syncResultJSON {
+	// A record is "planned" only when it is a not-yet-applied action, which the
+	// engine encodes as a planned_* outcome. res.Planned is unreliable here: the
+	// execute path copies the plan item without clearing the flag, so executed
+	// results (e.g. outcome "fetched") would otherwise still report planned=true.
+	planned := strings.HasPrefix(string(res.Outcome), "planned_")
+
+	// Planned entries carry a dry-run sentinel in Error rather than a real
+	// failure or skip reason, so drop the error field for them. This matches the
+	// MCP plan_sync shape, which omits error on plan entries.
+	errText := res.Error
+	if planned {
+		errText = ""
+	}
+
 	return syncResultJSON{
 		RepoID:     res.RepoID,
 		Path:       res.Path,
 		Action:     res.Action,
 		Outcome:    string(res.Outcome),
 		OK:         res.OK,
-		Planned:    res.Planned,
-		Error:      res.Error,
+		Planned:    planned,
+		Error:      errText,
 		SkipReason: res.SkipReason,
 	}
 }

--- a/cmd/repokeeper/sync.go
+++ b/cmd/repokeeper/sync.go
@@ -167,7 +167,7 @@ var syncCmd = &cobra.Command{
 		switch mode.kind {
 		case outputKindJSON:
 			setColorOutputMode(cmd, string(mode.kind))
-			data, err := json.MarshalIndent(results, "", "  ")
+			data, err := json.MarshalIndent(toSyncResultJSONs(results), "", "  ")
 			if err != nil {
 				return err
 			}
@@ -227,6 +227,44 @@ func init() {
 	syncCmd.Flags().Bool("wrap", false, "allow table columns to wrap instead of truncating")
 	addVCSFlag(syncCmd)
 
+}
+
+// syncResultJSON is the stable, machine-readable shape emitted by
+// `reconcile` / `sync -o json`. It is a thin snake_case projection of
+// engine.SyncResult and intentionally mirrors the MCP plan_sync/execute_sync
+// result shape (internal/mcpserver syncPlanEntry/syncResultEntry) so CLI and
+// MCP consumers parse the same fields. Adding a field is non-breaking; renaming
+// or removing one, or changing a value's meaning, is a contract break.
+type syncResultJSON struct {
+	RepoID     string `json:"repo_id"`
+	Path       string `json:"path"`
+	Action     string `json:"action"`
+	Outcome    string `json:"outcome"`
+	OK         bool   `json:"ok"`
+	Planned    bool   `json:"planned,omitempty"`
+	Error      string `json:"error,omitempty"`
+	SkipReason string `json:"skip_reason,omitempty"`
+}
+
+func toSyncResultJSON(res engine.SyncResult) syncResultJSON {
+	return syncResultJSON{
+		RepoID:     res.RepoID,
+		Path:       res.Path,
+		Action:     res.Action,
+		Outcome:    string(res.Outcome),
+		OK:         res.OK,
+		Planned:    res.Planned,
+		Error:      res.Error,
+		SkipReason: res.SkipReason,
+	}
+}
+
+func toSyncResultJSONs(results []engine.SyncResult) []syncResultJSON {
+	out := make([]syncResultJSON, 0, len(results))
+	for _, res := range results {
+		out = append(out, toSyncResultJSON(res))
+	}
+	return out
 }
 
 func writeSyncPlan(cmd *cobra.Command, plan []engine.SyncResult, cwd string, roots []string) error {

--- a/cmd/repokeeper/sync_json_test.go
+++ b/cmd/repokeeper/sync_json_test.go
@@ -44,7 +44,7 @@ var _ = Describe("sync -o json result shape", func() {
 		Expect(obj).NotTo(HaveKey("planned"))
 	})
 
-	It("emits outcome, ok and the skip reason for a skipped repo", func() {
+	It("emits outcome, ok and the error reason for a skipped repo", func() {
 		obj := marshalOne(engine.SyncResult{
 			RepoID:  "github.com/org/no-upstream",
 			Path:    "/work/org/no-upstream",
@@ -57,6 +57,20 @@ var _ = Describe("sync -o json result shape", func() {
 		Expect(obj).To(HaveKeyWithValue("outcome", "skipped_no_upstream"))
 		Expect(obj).To(HaveKeyWithValue("ok", true))
 		Expect(obj).To(HaveKeyWithValue("error", engine.SyncErrorSkippedNoUpstream))
+	})
+
+	It("emits the typed skip_reason for a skipped local update", func() {
+		obj := marshalOne(engine.SyncResult{
+			RepoID:     "github.com/org/dirty",
+			Path:       "/work/org/dirty",
+			Outcome:    engine.SyncOutcomeSkippedLocalUpdate,
+			OK:         true,
+			SkipReason: engine.SyncReasonDirtyWorkingTree,
+		})
+
+		Expect(obj).To(HaveKeyWithValue("outcome", "skipped_local_update"))
+		Expect(obj).To(HaveKeyWithValue("ok", true))
+		Expect(obj).To(HaveKeyWithValue("skip_reason", engine.SyncReasonDirtyWorkingTree))
 	})
 
 	It("marks dry-run entries planned and suppresses the dry-run sentinel", func() {

--- a/cmd/repokeeper/sync_json_test.go
+++ b/cmd/repokeeper/sync_json_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+package repokeeper
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/skaphos/repokeeper/internal/engine"
+)
+
+// These specs lock the stable `reconcile` / `sync -o json` contract (SKA-207):
+// a top-level JSON array of per-repo objects keyed with snake_case fields that
+// mirror the MCP plan_sync/execute_sync shape.
+var _ = Describe("sync -o json result shape", func() {
+	marshalOne := func(res engine.SyncResult) map[string]any {
+		data, err := json.Marshal(toSyncResultJSONs([]engine.SyncResult{res}))
+		Expect(err).NotTo(HaveOccurred())
+
+		var arr []map[string]any
+		Expect(json.Unmarshal(data, &arr)).To(Succeed())
+		Expect(arr).To(HaveLen(1), "output must be a JSON array of result objects")
+		return arr[0]
+	}
+
+	It("emits stable snake_case keys for a successful fetch", func() {
+		obj := marshalOne(engine.SyncResult{
+			RepoID:  "github.com/org/repo",
+			Path:    "/work/org/repo",
+			Action:  "git fetch --all --prune",
+			Outcome: engine.SyncOutcomeFetched,
+			OK:      true,
+		})
+
+		Expect(obj).To(HaveKeyWithValue("repo_id", "github.com/org/repo"))
+		Expect(obj).To(HaveKeyWithValue("path", "/work/org/repo"))
+		Expect(obj).To(HaveKeyWithValue("outcome", "fetched"))
+		Expect(obj).To(HaveKeyWithValue("ok", true))
+		Expect(obj).To(HaveKeyWithValue("action", "git fetch --all --prune"))
+		// error/skip_reason/planned are omitted when empty for a clean success record.
+		Expect(obj).NotTo(HaveKey("error"))
+		Expect(obj).NotTo(HaveKey("skip_reason"))
+		Expect(obj).NotTo(HaveKey("planned"))
+	})
+
+	It("emits outcome, ok and the skip reason for a skipped repo", func() {
+		obj := marshalOne(engine.SyncResult{
+			RepoID:  "github.com/org/no-upstream",
+			Path:    "/work/org/no-upstream",
+			Outcome: engine.SyncOutcomeSkippedNoUpstream,
+			OK:      true,
+			Error:   engine.SyncErrorSkippedNoUpstream,
+		})
+
+		Expect(obj).To(HaveKeyWithValue("repo_id", "github.com/org/no-upstream"))
+		Expect(obj).To(HaveKeyWithValue("outcome", "skipped_no_upstream"))
+		Expect(obj).To(HaveKeyWithValue("ok", true))
+		Expect(obj).To(HaveKeyWithValue("error", engine.SyncErrorSkippedNoUpstream))
+	})
+
+	It("marks dry-run entries planned and reports the planned outcome", func() {
+		obj := marshalOne(engine.SyncResult{
+			RepoID:  "github.com/org/repo",
+			Path:    "/work/org/repo",
+			Outcome: engine.SyncOutcomePlannedFetch,
+			OK:      true,
+			Planned: true,
+		})
+
+		Expect(obj).To(HaveKeyWithValue("planned", true))
+		Expect(obj).To(HaveKeyWithValue("outcome", "planned_fetch"))
+	})
+})

--- a/cmd/repokeeper/sync_json_test.go
+++ b/cmd/repokeeper/sync_json_test.go
@@ -59,16 +59,38 @@ var _ = Describe("sync -o json result shape", func() {
 		Expect(obj).To(HaveKeyWithValue("error", engine.SyncErrorSkippedNoUpstream))
 	})
 
-	It("marks dry-run entries planned and reports the planned outcome", func() {
+	It("marks dry-run entries planned and suppresses the dry-run sentinel", func() {
+		// Plan entries from the engine carry both Planned=true and a dry-run
+		// sentinel ("dry-run") in Error; that sentinel must not surface in JSON.
 		obj := marshalOne(engine.SyncResult{
 			RepoID:  "github.com/org/repo",
 			Path:    "/work/org/repo",
 			Outcome: engine.SyncOutcomePlannedFetch,
 			OK:      true,
 			Planned: true,
+			Error:   "dry-run",
 		})
 
 		Expect(obj).To(HaveKeyWithValue("planned", true))
 		Expect(obj).To(HaveKeyWithValue("outcome", "planned_fetch"))
+		Expect(obj).NotTo(HaveKey("error"))
+	})
+
+	It("does not report executed results as planned", func() {
+		// The execute path copies the plan item without clearing Planned, so an
+		// executed "fetched" result still has Planned=true on the struct. The
+		// JSON projection must derive planned from the outcome, not that flag.
+		obj := marshalOne(engine.SyncResult{
+			RepoID:  "github.com/org/repo",
+			Path:    "/work/org/repo",
+			Action:  "git fetch --all --prune",
+			Outcome: engine.SyncOutcomeFetched,
+			OK:      true,
+			Planned: true,
+		})
+
+		Expect(obj).To(HaveKeyWithValue("outcome", "fetched"))
+		Expect(obj).To(HaveKeyWithValue("ok", true))
+		Expect(obj).NotTo(HaveKey("planned"))
 	})
 })


### PR DESCRIPTION
## Summary

Implements **SKA-207**: stable, machine-readable `-o json` output for `repokeeper reconcile` (alias `sync`).

Previously the JSON path marshalled the raw `engine.SyncResult` struct, which has **no JSON tags** — so it leaked Go field names (`RepoID`, `OK`, `Action`, `Planned`…) instead of a stable contract. This adds a snake_case `syncResultJSON` DTO that mirrors the existing MCP `plan_sync`/`execute_sync` result shape, so CLI and MCP consumers parse identical fields.

## Shape

Top-level JSON **array** of per-repo records (matching `scan`/`repair-upstream`; only the `get`/`status` collection is enveloped):

```json
[
  { "repo_id": "github.com/org/repo", "path": "…", "action": "git fetch --all --prune", "outcome": "fetched", "ok": true },
  { "repo_id": "github.com/org/no-upstream", "path": "…", "outcome": "skipped_no_upstream", "ok": true, "error": "skipped-no-upstream" }
]
```

`--dry-run -o json` emits the planned variants (`planned_fetch`, …) with `planned: true`. `error`/`skip_reason` are omitted when empty.

## Acceptance criteria

- [x] `reconcile -o json` emits a JSON array of per-repo result objects
- [x] Each record includes `repo_id`, `path`, `outcome`, `error` (+ `action`, `ok`, `planned`, `skip_reason`)
- [x] Exit-code behavior unchanged
- [x] `--dry-run -o json` emits planned outcomes without executing
- [x] `reconcile --help` documents `-o json`
- [x] Default text output unchanged
- [x] Tests assert the JSON shape for success and skip outcomes

## Changes

- `cmd/repokeeper/sync.go` — `syncResultJSON` DTO + mappers; JSON case emits the stable shape
- `cmd/repokeeper/sync_json_test.go` *(new)* — specs for success / skip / dry-run-planned
- `cmd/repokeeper/command_run_test.go` — end-to-end assertion updated to stable keys
- `DESIGN.md` §6.4 — documents the sync JSON contract

## Verification

- `go build ./...`, `go vet`, `golangci-lint run` (0 issues), `go test ./...` — all pass