### PR TITLE
test(tui): lock sync plan confirm/cancel footer (SKA-202)

### DIFF
--- a/internal/tui/sync_test.go
+++ b/internal/tui/sync_test.go
@@ -88,6 +88,30 @@ func TestHandleSyncPlanError(t *testing.T) {
 	}
 }
 
+func TestRenderSyncPlanViewShowsConfirmCancelFooter(t *testing.T) {
+	t.Parallel()
+
+	plan := []engine.SyncResult{{RepoID: "acme/backend", Planned: true, Action: "git fetch"}}
+	m := tuiModel{mode: viewSyncPlan, syncPlan: plan, width: 120, height: 20}
+
+	out := renderSyncPlanView(m)
+
+	// The plan view must make the confirm/cancel choice explicit before any
+	// sync executes (SKA-202): both modal buttons and a keybinding footer.
+	for _, want := range []string{
+		"Sync Plan",
+		"acme/backend",
+		"Cancel",
+		"Confirm sync",
+		"enter: confirm",
+		"esc: cancel",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected sync plan view to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
 func TestHandleSyncPlanKeyConfirm(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

SKA-202 asked for an explicit confirm/cancel keybinding footer on the TUI sync plan view. On review, the behavior is **already implemented** — the view has since gained `Cancel` / `Confirm sync` buttons and a keybinding footer, `Esc` cancels without executing, and no network activity occurs until Enter+Confirm.

The one genuine gap: existing tests only exercised **key handling**, never the **rendered view output**. This PR adds `TestRenderSyncPlanViewShowsConfirmCancelFooter` to lock the footer/buttons so they can't silently regress.

## AC status (all already met)

- [x] `viewSyncPlan` renders a confirm/cancel footer — `internal/tui/sync.go:75-78`
- [x] `Esc` returns to `viewList` without executing — `update.go:214-218`, `TestHandleSyncPlanKeyCancel`
- [x] Footer style consistent with `viewResetConfirm` / `viewRepairConfirm`
- [x] No sync network activity until `Enter` — plan built with `DryRun: true`, `TestHandleSyncPlanKeyConfirm`
- [x] Test confirms the flow — **this PR** adds the missing view-render assertion

## Note on wording

The issue's example hint was `[Enter] Execute  [Esc] Cancel`, but the live wording `enter: confirm  esc: cancel` matches the other confirm views and therefore honors the "consistent with existing confirm views" AC. Rewording only this view would break that consistency, so it was left as-is.

## Testing

- `go test ./internal/tui/` — pass
- `golangci-lint run ./internal/tui/` — 0 issues

Closes SKA-202.