### PR TITLE
feat(get): suggest repair-upstream for gone repos

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -584,6 +584,7 @@ Top-level:
         "ahead": 2,
         "behind": 0
       },
+      "repair_upstream_suggestion": true,
       "submodules": { "has_submodules": true },
       "last_sync": { "ok": true, "at": "…", "error": "" }
     }
@@ -597,6 +598,7 @@ Field notes:
 * **`remotes`** — all configured remotes for the repo, not just one. The `primary_remote` field indicates which remote was used for `repo_id` derivation.
 * **`primary_remote`** — preference order: `origin` > first alphabetically. Used for repo identity and tracking status.
 * **`tracking.ahead`** / **`tracking.behind`** — integer counts. Both `0` when `status` is `"equal"`. Both `null` when `status` is `"gone"` or `"none"` (no upstream to compare against).
+* **`repair_upstream_suggestion`** — optional boolean emitted on repos with `tracking.status == "gone"`, indicating that `repokeeper repair-upstream <repo>` is the suggested recovery path.
 * **`apiVersion`** — identifies the schema of this JSON contract (see the stability policy below). When filtered to `diverged`, the top-level object additionally carries a `diverged` advice array; `apiVersion` is unchanged by that filter.
 
 #### JSON output schema stability policy

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -598,7 +598,7 @@ Field notes:
 * **`remotes`** — all configured remotes for the repo, not just one. The `primary_remote` field indicates which remote was used for `repo_id` derivation.
 * **`primary_remote`** — preference order: `origin` > first alphabetically. Used for repo identity and tracking status.
 * **`tracking.ahead`** / **`tracking.behind`** — integer counts. Both `0` when `status` is `"equal"`. Both `null` when `status` is `"gone"` or `"none"` (no upstream to compare against).
-* **`repair_upstream_suggestion`** — optional boolean emitted on repos with `tracking.status == "gone"`, indicating that `repokeeper repair-upstream <repo>` is the suggested recovery path.
+* **`repair_upstream_suggestion`** — optional boolean emitted on repos with `tracking.status == "gone"`, indicating that `repokeeper repair upstream` is the suggested inspection and repair path.
 * **`apiVersion`** — identifies the schema of this JSON contract (see the stability policy below). When filtered to `diverged`, the top-level object additionally carries a `diverged` advice array; `apiVersion` is unchanged by that filter.
 
 #### JSON output schema stability policy

--- a/cmd/repokeeper/repair_upstream.go
+++ b/cmd/repokeeper/repair_upstream.go
@@ -250,7 +250,7 @@ func needsUpstreamRepair(repo model.RepoStatus, targetUpstream string) bool {
 	if current != target {
 		return true
 	}
-	return repo.Tracking.Status == model.TrackingNone
+	return repo.Tracking.Status == model.TrackingNone || repo.Tracking.Status == model.TrackingGone
 }
 
 func resolveUpstreamTargetBranch(entry registry.Entry, repo model.RepoStatus, cfg *config.Config) string {

--- a/cmd/repokeeper/repair_upstream_test.go
+++ b/cmd/repokeeper/repair_upstream_test.go
@@ -33,6 +33,10 @@ func TestNeedsUpstreamRepair(t *testing.T) {
 	if !needsUpstreamRepair(repo, "origin/main") {
 		t.Fatal("expected missing tracking to need repair")
 	}
+	repo.Tracking = model.Tracking{Upstream: "origin/main", Status: model.TrackingGone}
+	if !needsUpstreamRepair(repo, "origin/main") {
+		t.Fatal("expected gone upstream to need repair")
+	}
 	if needsUpstreamRepair(repo, "  ") {
 		t.Fatal("expected blank target upstream to skip repair")
 	}

--- a/cmd/repokeeper/status.go
+++ b/cmd/repokeeper/status.go
@@ -424,7 +424,7 @@ func writeRepairUpstreamHint(cmd *cobra.Command, report *model.StatusReport) err
 	if count == 0 {
 		return nil
 	}
-	_, err := fmt.Fprintf(cmd.ErrOrStderr(), "hint: %d repo(s) have gone upstream - run 'repokeeper repair-upstream <repo>' to fix\n", count)
+	_, err := fmt.Fprintf(cmd.ErrOrStderr(), "hint: %d repo(s) have gone upstream - run 'repokeeper repair upstream' to inspect and repair\n", count)
 	return err
 }
 

--- a/cmd/repokeeper/status.go
+++ b/cmd/repokeeper/status.go
@@ -44,7 +44,8 @@ type remoteMismatchPlan = engine.RemoteMismatchPlan
 
 type statusJSONRepo struct {
 	model.RepoStatus
-	LocalLabels map[string]string `json:"local_labels,omitempty"`
+	LocalLabels              map[string]string `json:"local_labels,omitempty"`
+	RepairUpstreamSuggestion bool              `json:"repair_upstream_suggestion,omitempty"`
 }
 
 // statusJSONAPIVersion identifies the schema of the `get`/`status -o json`
@@ -244,6 +245,7 @@ var statusCmd = &cobra.Command{
 				break
 			}
 			logOutputWriteFailure(cmd, "status table", writeStatusTable(cmd, report, cwd, []string{cfgRoot}, noHeaders, false))
+			logOutputWriteFailure(cmd, "status repair-upstream hint", writeRepairUpstreamHint(cmd, report))
 		case outputKindWide:
 			setColorOutputMode(cmd, string(mode.kind))
 			if filter == engine.FilterDiverged {
@@ -251,6 +253,7 @@ var statusCmd = &cobra.Command{
 				break
 			}
 			logOutputWriteFailure(cmd, "status wide", writeStatusTable(cmd, report, cwd, []string{cfgRoot}, noHeaders, true))
+			logOutputWriteFailure(cmd, "status repair-upstream hint", writeRepairUpstreamHint(cmd, report))
 		default:
 			return fmt.Errorf("unsupported format %q", format)
 		}
@@ -272,8 +275,9 @@ func buildStatusJSONOutput(report *model.StatusReport, includeDiverged bool) any
 		jsonReport.Repos = make([]statusJSONRepo, 0, len(repos))
 		for _, repo := range repos {
 			jsonReport.Repos = append(jsonReport.Repos, statusJSONRepo{
-				RepoStatus:  repo,
-				LocalLabels: cloneMetadataMap(repo.Labels),
+				RepoStatus:               repo,
+				LocalLabels:              cloneMetadataMap(repo.Labels),
+				RepairUpstreamSuggestion: repo.Tracking.Status == model.TrackingGone,
 			})
 		}
 	}
@@ -410,6 +414,31 @@ func writeStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string
 		}
 	}
 	return w.Flush()
+}
+
+func writeRepairUpstreamHint(cmd *cobra.Command, report *model.StatusReport) error {
+	if isQuiet(cmd) {
+		return nil
+	}
+	count := countGoneRepos(report)
+	if count == 0 {
+		return nil
+	}
+	_, err := fmt.Fprintf(cmd.ErrOrStderr(), "hint: %d repo(s) have gone upstream - run 'repokeeper repair-upstream <repo>' to fix\n", count)
+	return err
+}
+
+func countGoneRepos(report *model.StatusReport) int {
+	if report == nil {
+		return 0
+	}
+	count := 0
+	for _, repo := range report.Repos {
+		if repo.Tracking.Status == model.TrackingGone {
+			count++
+		}
+	}
+	return count
 }
 
 func writeDivergedStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string, roots []string, noHeaders bool, wide bool) error {

--- a/cmd/repokeeper/status_helpers_test.go
+++ b/cmd/repokeeper/status_helpers_test.go
@@ -2,6 +2,7 @@
 package repokeeper
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/skaphos/repokeeper/internal/model"
+	"github.com/spf13/cobra"
 )
 
 func TestRelatedReposString(t *testing.T) {
@@ -114,6 +116,101 @@ func TestStatusJSONOutputIncludesAPIVersion(t *testing.T) {
 		// The existing repos field must remain alongside the diverged advice.
 		assertArrayLen(t, doc, "repos", len(report.Repos))
 		assertArrayLen(t, doc, "diverged", 1)
+	})
+}
+
+func TestStatusJSONOutputFlagsGoneRepairSuggestion(t *testing.T) {
+	t.Parallel()
+
+	report := &model.StatusReport{
+		GeneratedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+		Repos: []model.RepoStatus{
+			{RepoID: "github.com/org/gone", Path: "/repos/gone", Tracking: model.Tracking{Status: model.TrackingGone}},
+			{RepoID: "github.com/org/clean", Path: "/repos/clean", Tracking: model.Tracking{Status: model.TrackingEqual}},
+		},
+	}
+
+	raw, err := json.Marshal(buildStatusJSONOutput(report, false))
+	if err != nil {
+		t.Fatalf("marshal status json: %v", err)
+	}
+	var doc struct {
+		Repos []struct {
+			RepoID                   string `json:"repo_id"`
+			RepairUpstreamSuggestion bool   `json:"repair_upstream_suggestion"`
+		} `json:"repos"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal status json: %v\n%s", err, raw)
+	}
+	if len(doc.Repos) != 2 {
+		t.Fatalf("repos length = %d, want 2", len(doc.Repos))
+	}
+	if !doc.Repos[0].RepairUpstreamSuggestion {
+		t.Fatalf("expected gone repo to carry repair_upstream_suggestion: %s", raw)
+	}
+	if doc.Repos[1].RepairUpstreamSuggestion {
+		t.Fatalf("did not expect clean repo to carry repair_upstream_suggestion: %s", raw)
+	}
+}
+
+func TestWriteRepairUpstreamHint(t *testing.T) {
+	t.Parallel()
+
+	report := &model.StatusReport{Repos: []model.RepoStatus{
+		{Tracking: model.Tracking{Status: model.TrackingGone}},
+		{Tracking: model.Tracking{Status: model.TrackingEqual}},
+		{Tracking: model.Tracking{Status: model.TrackingGone}},
+	}}
+
+	t.Run("writes hint for gone repos", func(t *testing.T) {
+		t.Parallel()
+		errOut := &bytes.Buffer{}
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("quiet", false, "")
+		cmd.SetErr(errOut)
+
+		if err := writeRepairUpstreamHint(cmd, report); err != nil {
+			t.Fatalf("write hint: %v", err)
+		}
+		got := errOut.String()
+		if !strings.Contains(got, "hint: 2 repo(s) have gone upstream") {
+			t.Fatalf("expected gone hint count, got %q", got)
+		}
+		if !strings.Contains(got, "repokeeper repair-upstream <repo>") {
+			t.Fatalf("expected repair-upstream command hint, got %q", got)
+		}
+	})
+
+	t.Run("omits hint without gone repos", func(t *testing.T) {
+		t.Parallel()
+		errOut := &bytes.Buffer{}
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("quiet", false, "")
+		cmd.SetErr(errOut)
+
+		cleanReport := &model.StatusReport{Repos: []model.RepoStatus{{Tracking: model.Tracking{Status: model.TrackingEqual}}}}
+		if err := writeRepairUpstreamHint(cmd, cleanReport); err != nil {
+			t.Fatalf("write hint: %v", err)
+		}
+		if got := errOut.String(); got != "" {
+			t.Fatalf("expected no hint without gone repos, got %q", got)
+		}
+	})
+
+	t.Run("quiet suppresses hint", func(t *testing.T) {
+		t.Parallel()
+		errOut := &bytes.Buffer{}
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("quiet", true, "")
+		cmd.SetErr(errOut)
+
+		if err := writeRepairUpstreamHint(cmd, report); err != nil {
+			t.Fatalf("write hint: %v", err)
+		}
+		if got := errOut.String(); got != "" {
+			t.Fatalf("expected quiet mode to suppress hint, got %q", got)
+		}
 	})
 }
 

--- a/cmd/repokeeper/status_helpers_test.go
+++ b/cmd/repokeeper/status_helpers_test.go
@@ -177,7 +177,7 @@ func TestWriteRepairUpstreamHint(t *testing.T) {
 		if !strings.Contains(got, "hint: 2 repo(s) have gone upstream") {
 			t.Fatalf("expected gone hint count, got %q", got)
 		}
-		if !strings.Contains(got, "repokeeper repair-upstream <repo>") {
+		if !strings.Contains(got, "repokeeper repair upstream") {
 			t.Fatalf("expected repair-upstream command hint, got %q", got)
 		}
 	})

--- a/internal/engine/engine_actions_import_repair_internal_test.go
+++ b/internal/engine/engine_actions_import_repair_internal_test.go
@@ -588,6 +588,9 @@ func TestRepairHelpers(t *testing.T) {
 		if !repairNeedsUpstream(model.RepoStatus{Tracking: model.Tracking{Upstream: "origin/main", Status: model.TrackingNone}}, "origin/main") {
 			t.Fatal("tracking none should require upstream re-set")
 		}
+		if !repairNeedsUpstream(model.RepoStatus{Tracking: model.Tracking{Upstream: "origin/main", Status: model.TrackingGone}}, "origin/main") {
+			t.Fatal("gone upstream should require upstream re-set")
+		}
 	})
 }
 

--- a/internal/engine/repair.go
+++ b/internal/engine/repair.go
@@ -150,5 +150,5 @@ func repairNeedsUpstream(status model.RepoStatus, target string) bool {
 	if current != t {
 		return true
 	}
-	return status.Tracking.Status == model.TrackingNone
+	return status.Tracking.Status == model.TrackingNone || status.Tracking.Status == model.TrackingGone
 }


### PR DESCRIPTION
## Summary

- append a quiet-aware table/wide hint when get/status reports repos with gone upstreams
- add repair_upstream_suggestion to JSON rows for gone repos
- document the optional JSON field in DESIGN.md

## Testing

- go test ./...
- git diff --check

Closes SKA-210