### PR TITLE
ci: notarize macOS binaries via GoReleaser + quill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # macOS notarization (cross-platform via quill). When these secrets are
+          # unset the notarize block is auto-skipped, so the release still works.
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
       - name: Attest release archives
         uses: actions/attest-build-provenance@v4.1.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,28 @@ builds:
       - -X github.com/skaphos/repokeeper/cmd/repokeeper.Commit={{.Commit}}
       - -X github.com/skaphos/repokeeper/cmd/repokeeper.Date={{.Date}}
 
+# macOS code signing + notarization, cross-platform via quill (no Mac runner
+# required). Auto-skipped unless MACOS_SIGN_P12 is set, so local/snapshot builds
+# and forks without the secrets are unaffected. Runs after build and before
+# archive, so the signed+notarized binary is what gets tarred, checksummed,
+# SBOM'd, and cosign-signed.
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - repokeeper
+      sign:
+        # base64-encoded Developer ID Application .p12 (certificate + private key)
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        # App Store Connect API key (issuer UUID, key ID, base64-encoded .p8)
+        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
+        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
+        key: "{{ .Env.MACOS_NOTARY_KEY }}"
+        wait: true
+        timeout: 20m
+
 archives:
   - id: default
     formats:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,13 +22,16 @@ builds:
       - -X github.com/skaphos/repokeeper/cmd/repokeeper.Date={{.Date}}
 
 # macOS code signing + notarization, cross-platform via quill (no Mac runner
-# required). Auto-skipped unless MACOS_SIGN_P12 is set, so local/snapshot builds
-# and forks without the secrets are unaffected. Runs after build and before
-# archive, so the signed+notarized binary is what gets tarred, checksummed,
-# SBOM'd, and cosign-signed.
+# required). Auto-skipped unless all five MACOS_* secrets are set, so local/
+# snapshot builds and forks without the secrets are unaffected. Runs after build
+# and before archive, so the signed+notarized binary is what gets tarred,
+# checksummed, SBOM'd, and cosign-signed.
 notarize:
   macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+    - enabled: >-
+        {{ and (isEnvSet "MACOS_SIGN_P12") (isEnvSet "MACOS_SIGN_PASSWORD")
+        (isEnvSet "MACOS_NOTARY_ISSUER_ID") (isEnvSet "MACOS_NOTARY_KEY_ID")
+        (isEnvSet "MACOS_NOTARY_KEY") }}
       ids:
         - repokeeper
       sign:


### PR DESCRIPTION
## What

Adds cross-platform macOS code signing + notarization to the release pipeline using GoReleaser's quill-backed `notarize.macos` block — no macOS runner required, the existing `ubuntu-latest` job is reused.

- New `notarize.macos` block in `.goreleaser.yaml`, placed pre-archive so the signed+notarized binary is what gets tarred, checksummed, SBOM'd, and cosign-signed.
- Five Apple secrets mapped into the GoReleaser step's `env:` in `release.yml`.

## Safe to merge before secrets exist

The block is gated on `enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'`. With the secrets unset (current state, forks, local/snapshot builds), notarization is silently skipped and the release works unchanged.

## Required secrets (add to repo before they take effect)

| Secret | Value |
|---|---|
| `MACOS_SIGN_P12` | base64 of the Developer ID Application `.p12` |
| `MACOS_SIGN_PASSWORD` | the `.p12` export password |
| `MACOS_NOTARY_ISSUER_ID` | App Store Connect Issuer ID (UUID) |
| `MACOS_NOTARY_KEY_ID` | App Store Connect Key ID |
| `MACOS_NOTARY_KEY` | base64 of the App Store Connect `.p8` |

## Follow-up (not in this PR)

The `xattr` quarantine-strip `postflight` in the cask is intentionally **kept** until a notarized release is verified (cut an RC tag, confirm quill's notarization succeeds), then removed separately. Removing it before notarization is live would reintroduce the Gatekeeper prompt.

## Validation

`goreleaser check` passes on 2.16.0.

> [!NOTE]
> Notarized artifacts are bare binaries in `.tar.gz`, which can't be stapled (only bundles/dmg/pkg). Gatekeeper does an online check on first run — fine for brew-installed CLIs.