### PR TITLE
feat(index): show unified diff of proposed vs existing repo metadata

### DIFF
--- a/cmd/repokeeper/index.go
+++ b/cmd/repokeeper/index.go
@@ -71,9 +71,6 @@ Pass --write to save the proposal. Overwriting an existing file requires
 		default:
 			return fmt.Errorf("load existing repo metadata: %w (use --force to replace)", existingErr)
 		}
-		if writeFile && existingErr == nil && !force {
-			return fmt.Errorf("repo metadata already exists at %s (use --force to overwrite)", existingPath)
-		}
 
 		proposal, err := buildIndexProposal(entry, existing, yes, promoteLocalLabels, cmd.InOrStdin(), cmd.ErrOrStderr())
 		if err != nil {
@@ -89,6 +86,11 @@ Pass --write to save the proposal. Overwriting an existing file requires
 		if !writeFile {
 			infof(cmd, "preview only; rerun with --write to save repo metadata")
 			return nil
+		}
+		// The diff/preview above is always shown first; only then enforce that
+		// overwriting an existing, loadable file requires --force.
+		if existingErr == nil && !force {
+			return fmt.Errorf("repo metadata already exists at %s (use --force to overwrite)", existingPath)
 		}
 		if !yes {
 			confirmed, err := confirmWithPrompt(cmd, fmt.Sprintf("Write repo metadata to %s? [y/N]: ", existingPath))
@@ -202,9 +204,6 @@ Pass --write to save the proposals. Overwriting existing files requires
 			default:
 				return fmt.Errorf("load existing repo metadata for %s: %w (use --force to replace)", entry.RepoID, existingErr)
 			}
-			if writeFile && existingErr == nil && !force {
-				return fmt.Errorf("repo metadata already exists at %s for %s (use --force to overwrite)", existingPath, entry.RepoID)
-			}
 			proposal := guessRepoMetadataDefaults(entry, existing)
 			proposal.Labels = mergePromotedLabels(proposal.Labels, entry.Labels)
 			proposals = append(proposals, bulkProposal{entry: entry, target: existingPath, proposal: proposal, existingErr: existingErr})
@@ -225,6 +224,15 @@ Pass --write to save the proposals. Overwriting existing files requires
 		if !writeFile {
 			infof(cmd, "preview only; rerun with --write to save repo metadata")
 			return nil
+		}
+		// Previews/diffs for every repo are shown above; only then enforce that
+		// overwriting an existing, loadable file requires --force.
+		if !force {
+			for _, proposal := range proposals {
+				if proposal.existingErr == nil {
+					return fmt.Errorf("repo metadata already exists at %s for %s (use --force to overwrite)", proposal.target, proposal.entry.RepoID)
+				}
+			}
 		}
 		if !yes {
 			confirmed, err := confirmWithPrompt(cmd, fmt.Sprintf("Write repo metadata for %d repositories? [y/N]: ", len(proposals)))
@@ -470,29 +478,34 @@ func fallbackMetadataPath(repoRoot, current string) string {
 	return filepath.Join(repoRoot, repometa.PreferredFilename)
 }
 
-// writeMetadataPreview renders an index proposal for the user. When a current
-// repo metadata file was loaded (existingErr == nil) it shows a unified diff of
-// that file against the proposed content, or a note when nothing would change.
-// Otherwise it prints the full proposed file. proposed must be the canonical
-// bytes Save would write (see repometa.Render).
-func writeMetadataPreview(out io.Writer, existingPath string, proposed []byte, existingErr error) error {
-	if existingErr == nil {
-		current, err := os.ReadFile(existingPath)
-		if err != nil {
-			return fmt.Errorf("read existing repo metadata: %w", err)
-		}
-		diff, err := unifiedDiff(current, proposed, existingPath)
-		if err != nil {
-			return err
-		}
-		if diff == "" {
-			_, err := fmt.Fprintf(out, "# Repo metadata unchanged\n# Target: %s\n", existingPath)
-			return err
-		}
-		_, err = fmt.Fprintf(out, "# Repo metadata diff\n# Target: %s\n%s", existingPath, diff)
+// writeMetadataPreview renders an index proposal for the user. Whenever a file
+// already exists at existingPath it shows a unified diff of that file's raw
+// bytes against the proposed content (or a note when nothing would change) —
+// even if the file could not be parsed/loaded, so a --force replace still shows
+// what would change. When no file exists it prints the full proposed file.
+// loadErr is the error from loading the existing metadata (if any) and is used
+// only to annotate the diff when the on-disk file could not be parsed. proposed
+// must be the canonical bytes Save would write (see repometa.Render).
+func writeMetadataPreview(out io.Writer, existingPath string, proposed []byte, loadErr error) error {
+	current, readErr := os.ReadFile(existingPath)
+	if readErr != nil {
+		// No existing file on disk (or it can't be read): show the full proposal.
+		_, err := fmt.Fprintf(out, "# Repo metadata preview\n# Target: %s\n%s", existingPath, string(proposed))
 		return err
 	}
-	_, err := fmt.Fprintf(out, "# Repo metadata preview\n# Target: %s\n%s", existingPath, string(proposed))
+	note := ""
+	if loadErr != nil && !errors.Is(loadErr, repometa.ErrNotFound) {
+		note = fmt.Sprintf("# note: existing file could not be parsed (%v); diffing raw contents\n", loadErr)
+	}
+	diff, err := unifiedDiff(current, proposed, existingPath)
+	if err != nil {
+		return err
+	}
+	if diff == "" {
+		_, err := fmt.Fprintf(out, "# Repo metadata unchanged\n# Target: %s\n%s", existingPath, note)
+		return err
+	}
+	_, err = fmt.Fprintf(out, "# Repo metadata diff\n# Target: %s\n%s%s", existingPath, note, diff)
 	return err
 }
 

--- a/cmd/repokeeper/index.go
+++ b/cmd/repokeeper/index.go
@@ -3,6 +3,7 @@ package repokeeper
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/skaphos/repokeeper/internal/config"
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/registry"
@@ -23,7 +25,16 @@ import (
 var indexCmd = &cobra.Command{
 	Use:   "index <repo-id-or-path>",
 	Short: "Interactively propose repo-local metadata for a tracked repository",
-	Args:  cobra.ExactArgs(1),
+	Long: `Interactively propose repo-local metadata for a tracked repository.
+
+By default the command previews the proposed .repokeeper-repo.yaml without
+writing it. When the repository already has a metadata file, the preview is
+rendered as a unified diff of the current file against the proposed content
+(or a note that it is unchanged); otherwise the full proposed file is shown.
+
+Pass --write to save the proposal. Overwriting an existing file requires
+--force, and the diff is shown before the write is confirmed.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -69,13 +80,11 @@ var indexCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		proposal.APIVersion = repometa.APIVersion
-		proposal.Kind = repometa.Kind
-		preview, err := yaml.Marshal(proposal)
+		proposed, err := repometa.Render(proposal)
 		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "# Repo metadata preview\n# Target: %s\n%s", existingPath, string(preview)); err != nil {
+		if err := writeMetadataPreview(cmd.OutOrStdout(), existingPath, proposed, existingErr); err != nil {
 			return err
 		}
 		if !writeFile {
@@ -449,6 +458,48 @@ func fallbackMetadataPath(repoRoot, current string) string {
 		return current
 	}
 	return filepath.Join(repoRoot, repometa.PreferredFilename)
+}
+
+// writeMetadataPreview renders an index proposal for the user. When a current
+// repo metadata file was loaded (existingErr == nil) it shows a unified diff of
+// that file against the proposed content, or a note when nothing would change.
+// Otherwise it prints the full proposed file. proposed must be the canonical
+// bytes Save would write (see repometa.Render).
+func writeMetadataPreview(out io.Writer, existingPath string, proposed []byte, existingErr error) error {
+	if existingErr == nil {
+		current, err := os.ReadFile(existingPath)
+		if err != nil {
+			return fmt.Errorf("read existing repo metadata: %w", err)
+		}
+		diff, err := unifiedDiff(current, proposed, existingPath)
+		if err != nil {
+			return err
+		}
+		if diff == "" {
+			_, err := fmt.Fprintf(out, "# Repo metadata unchanged\n# Target: %s\n", existingPath)
+			return err
+		}
+		_, err = fmt.Fprintf(out, "# Repo metadata diff\n# Target: %s\n%s", existingPath, diff)
+		return err
+	}
+	_, err := fmt.Fprintf(out, "# Repo metadata preview\n# Target: %s\n%s", existingPath, string(proposed))
+	return err
+}
+
+// unifiedDiff returns a unified diff describing the change from current to
+// proposed for the file at path, with three lines of context. It returns an
+// empty string when the two are identical.
+func unifiedDiff(current, proposed []byte, path string) (string, error) {
+	if bytes.Equal(current, proposed) {
+		return "", nil
+	}
+	return difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(current)),
+		B:        difflib.SplitLines(string(proposed)),
+		FromFile: path + " (current)",
+		ToFile:   path + " (proposed)",
+		Context:  3,
+	})
 }
 
 func detectReadmeEntrypoint(repoRoot string) string {

--- a/cmd/repokeeper/index.go
+++ b/cmd/repokeeper/index.go
@@ -19,7 +19,6 @@ import (
 	"github.com/skaphos/repokeeper/internal/repometa"
 	"github.com/skaphos/repokeeper/internal/selector"
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v3"
 )
 
 var indexCmd = &cobra.Command{
@@ -128,7 +127,16 @@ Pass --write to save the proposal. Overwriting an existing file requires
 var indexReposCmd = &cobra.Command{
 	Use:   "repos",
 	Short: "Preview or write repo-local metadata for selected repositories",
-	Args:  cobra.NoArgs,
+	Long: `Preview or write repo-local metadata for selected repositories.
+
+Each selected repository is previewed in turn. When a repository already has a
+.repokeeper-repo.yaml, its preview is rendered as a unified diff of the current
+file against the proposed content (or a note that it is unchanged); otherwise
+the full proposed file is shown.
+
+Pass --write to save the proposals. Overwriting existing files requires
+--force, and the diffs are shown before the write is confirmed.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -177,9 +185,10 @@ var indexReposCmd = &cobra.Command{
 		}
 
 		type bulkProposal struct {
-			entry    registry.Entry
-			target   string
-			proposal *model.RepoMetadata
+			entry       registry.Entry
+			target      string
+			proposal    *model.RepoMetadata
+			existingErr error
 		}
 		proposals := make([]bulkProposal, 0, len(selected))
 		for _, entry := range selected {
@@ -198,17 +207,18 @@ var indexReposCmd = &cobra.Command{
 			}
 			proposal := guessRepoMetadataDefaults(entry, existing)
 			proposal.Labels = mergePromotedLabels(proposal.Labels, entry.Labels)
-			proposal.APIVersion = repometa.APIVersion
-			proposal.Kind = repometa.Kind
-			proposals = append(proposals, bulkProposal{entry: entry, target: existingPath, proposal: proposal})
+			proposals = append(proposals, bulkProposal{entry: entry, target: existingPath, proposal: proposal, existingErr: existingErr})
 		}
 
 		for _, proposal := range proposals {
-			preview, err := yaml.Marshal(proposal.proposal)
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "# Repo: %s\n", proposal.entry.RepoID); err != nil {
+				return err
+			}
+			proposed, err := repometa.Render(proposal.proposal)
 			if err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "# Repo metadata preview\n# Repo: %s\n# Target: %s\n%s", proposal.entry.RepoID, proposal.target, string(preview)); err != nil {
+			if err := writeMetadataPreview(cmd.OutOrStdout(), proposal.target, proposed, proposal.existingErr); err != nil {
 				return err
 			}
 		}

--- a/cmd/repokeeper/index_test.go
+++ b/cmd/repokeeper/index_test.go
@@ -3,6 +3,7 @@ package repokeeper
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -315,6 +316,30 @@ func TestWriteMetadataPreviewShowsDiff(t *testing.T) {
 	for _, want := range []string{"-name: Old Name", "+name: New Name"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected diff to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteMetadataPreviewDiffsUnparseableExisting(t *testing.T) {
+	t.Parallel()
+	proposed, err := repometa.Render(&model.RepoMetadata{Name: "Repo", RepoID: "acme/repo"})
+	if err != nil {
+		t.Fatalf("render proposal: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), repometa.PreferredFilename)
+	// Existing on-disk file that is present but not valid metadata.
+	if err := os.WriteFile(target, []byte("name: [unterminated\n"), 0o644); err != nil {
+		t.Fatalf("seed existing file: %v", err)
+	}
+	var out bytes.Buffer
+	loadErr := errors.New("parse .repokeeper-repo.yaml: yaml: bad indentation")
+	if err := writeMetadataPreview(&out, target, proposed, loadErr); err != nil {
+		t.Fatalf("write preview: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"# Repo metadata diff", "could not be parsed", "+name: Repo"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected diff of unparseable existing file to contain %q, got:\n%s", want, got)
 		}
 	}
 }

--- a/cmd/repokeeper/index_test.go
+++ b/cmd/repokeeper/index_test.go
@@ -219,3 +219,102 @@ func TestGuessRepoMetadataDefaultsClonesExistingMetadata(t *testing.T) {
 		t.Fatalf("expected related repos slice clone, got %#v", existing.RelatedRepos)
 	}
 }
+
+func TestUnifiedDiffEmptyWhenIdentical(t *testing.T) {
+	t.Parallel()
+	content := []byte("name: Repo\nrepoID: acme/repo\n")
+	got, err := unifiedDiff(content, content, "/repo/.repokeeper-repo.yaml")
+	if err != nil {
+		t.Fatalf("unified diff: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty diff for identical content, got %q", got)
+	}
+}
+
+func TestUnifiedDiffReportsChanges(t *testing.T) {
+	t.Parallel()
+	current := []byte("name: Old Name\nrepoID: acme/repo\n")
+	proposed := []byte("name: New Name\nrepoID: acme/repo\n")
+	got, err := unifiedDiff(current, proposed, "/repo/.repokeeper-repo.yaml")
+	if err != nil {
+		t.Fatalf("unified diff: %v", err)
+	}
+	for _, want := range []string{"(current)", "(proposed)", "-name: Old Name", "+name: New Name"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected diff to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteMetadataPreviewNewFile(t *testing.T) {
+	t.Parallel()
+	proposed, err := repometa.Render(&model.RepoMetadata{Name: "Repo", RepoID: "acme/repo"})
+	if err != nil {
+		t.Fatalf("render proposal: %v", err)
+	}
+	var out bytes.Buffer
+	target := filepath.Join(t.TempDir(), repometa.PreferredFilename)
+	if err := writeMetadataPreview(&out, target, proposed, repometa.ErrNotFound); err != nil {
+		t.Fatalf("write preview: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "# Repo metadata preview") {
+		t.Fatalf("expected full preview header, got:\n%s", got)
+	}
+	if !strings.Contains(got, string(proposed)) {
+		t.Fatalf("expected full proposed file in preview, got:\n%s", got)
+	}
+}
+
+func TestWriteMetadataPreviewUnchanged(t *testing.T) {
+	t.Parallel()
+	proposed, err := repometa.Render(&model.RepoMetadata{Name: "Repo", RepoID: "acme/repo"})
+	if err != nil {
+		t.Fatalf("render proposal: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), repometa.PreferredFilename)
+	if err := os.WriteFile(target, proposed, 0o644); err != nil {
+		t.Fatalf("seed existing file: %v", err)
+	}
+	var out bytes.Buffer
+	if err := writeMetadataPreview(&out, target, proposed, nil); err != nil {
+		t.Fatalf("write preview: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "# Repo metadata unchanged") {
+		t.Fatalf("expected unchanged note, got:\n%s", got)
+	}
+	if strings.Contains(got, "@@") {
+		t.Fatalf("did not expect a diff body for unchanged content, got:\n%s", got)
+	}
+}
+
+func TestWriteMetadataPreviewShowsDiff(t *testing.T) {
+	t.Parallel()
+	current, err := repometa.Render(&model.RepoMetadata{Name: "Old Name", RepoID: "acme/repo"})
+	if err != nil {
+		t.Fatalf("render current: %v", err)
+	}
+	proposed, err := repometa.Render(&model.RepoMetadata{Name: "New Name", RepoID: "acme/repo"})
+	if err != nil {
+		t.Fatalf("render proposal: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), repometa.PreferredFilename)
+	if err := os.WriteFile(target, current, 0o644); err != nil {
+		t.Fatalf("seed existing file: %v", err)
+	}
+	var out bytes.Buffer
+	if err := writeMetadataPreview(&out, target, proposed, nil); err != nil {
+		t.Fatalf("write preview: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "# Repo metadata diff") {
+		t.Fatalf("expected diff header, got:\n%s", got)
+	}
+	for _, want := range []string{"-name: Old Name", "+name: New Name"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected diff to contain %q, got:\n%s", want, got)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.31.0
 	github.com/onsi/gomega v1.42.0
 	github.com/pelletier/go-toml/v2 v2.4.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/term v0.44.0
@@ -38,7 +39,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/internal/repometa/repometa.go
+++ b/internal/repometa/repometa.go
@@ -42,17 +42,36 @@ func Load(repoRoot string) (string, *model.RepoMetadata, error) {
 	return path, &metadata, nil
 }
 
-func Save(repoRoot string, metadata *model.RepoMetadata, force bool) (string, error) {
-	if metadata == nil {
-		return "", fmt.Errorf("repo metadata is required")
-	}
-	normalized := normalize(*metadata)
+// canonicalize returns the normalized metadata with apiVersion/kind defaults
+// applied — the exact form Save persists. Shared by Save and Render so that a
+// previewed diff reflects the bytes that will actually be written.
+func canonicalize(metadata model.RepoMetadata) model.RepoMetadata {
+	normalized := normalize(metadata)
 	if normalized.APIVersion == "" {
 		normalized.APIVersion = APIVersion
 	}
 	if normalized.Kind == "" {
 		normalized.Kind = Kind
 	}
+	return normalized
+}
+
+// Render returns the canonical YAML bytes that Save would write for metadata,
+// without validating or touching the filesystem. It is used to preview a
+// proposal and to diff it against an existing repo metadata file.
+func Render(metadata *model.RepoMetadata) ([]byte, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("repo metadata is required")
+	}
+	canonical := canonicalize(*metadata)
+	return yaml.Marshal(&canonical)
+}
+
+func Save(repoRoot string, metadata *model.RepoMetadata, force bool) (string, error) {
+	if metadata == nil {
+		return "", fmt.Errorf("repo metadata is required")
+	}
+	normalized := canonicalize(*metadata)
 	if err := Validate(&normalized); err != nil {
 		return "", err
 	}

--- a/internal/repometa/repometa_test.go
+++ b/internal/repometa/repometa_test.go
@@ -2,6 +2,7 @@
 package repometa
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -80,6 +81,41 @@ func TestSaveWritesCanonicalFile(t *testing.T) {
 	}
 	if metadata.Labels["role"] != "docs" {
 		t.Fatalf("expected saved labels, got %#v", metadata.Labels)
+	}
+}
+
+func TestRenderMatchesSaveOutput(t *testing.T) {
+	t.Parallel()
+	meta := &model.RepoMetadata{
+		Name:   "Repo",
+		RepoID: "github.com/example/repo",
+		Labels: map[string]string{"role": "docs"},
+	}
+	rendered, err := Render(meta)
+	if err != nil {
+		t.Fatalf("render metadata: %v", err)
+	}
+	repo := t.TempDir()
+	path, err := Save(repo, meta, false)
+	if err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	if !bytes.Equal(rendered, saved) {
+		t.Fatalf("render output must equal saved file.\nrender:\n%s\nsaved:\n%s", rendered, saved)
+	}
+	if !strings.Contains(string(rendered), "apiVersion: "+APIVersion) {
+		t.Fatalf("expected canonical apiVersion marker in render output, got:\n%s", rendered)
+	}
+}
+
+func TestRenderRequiresMetadata(t *testing.T) {
+	t.Parallel()
+	if _, err := Render(nil); err == nil {
+		t.Fatal("expected error rendering nil metadata")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes SKA-206 (Phase 1). `index` now shows what a `--write` would actually change.

Previously `repokeeper index` always rendered the proposed `.repokeeper-repo.yaml` as a plain YAML block, with no indication of how it differs from an existing file. Now, when a metadata file already exists, the preview is a **unified diff** of the current file against the exact bytes that would be written (or a note that nothing changes). With no existing file, the full proposed file is shown as before. This aligns `index` — the only command that mutates source-controlled files — with the project's preview-first safety contract (ADR-0001).

## Changes

- **`repometa.Render`** + shared `canonicalize` helper: returns the canonical YAML bytes `Save` would write, without validating or touching disk. `Save` is refactored onto the same helper so **preview bytes equal written bytes byte-for-byte**.
- **`index` preview** diffs existing vs proposed (unified diff, 3 lines context) via `pmezard/go-difflib` (promoted from indirect to direct dep — no new third-party dependency). Shows an "unchanged" note when identical; full proposed file when no file exists.
- **`index --help`** documents the diff/preview/write/force behavior.
- 7 new tests (`repometa.Render` parity + nil; `unifiedDiff`; `writeMetadataPreview` for new/unchanged/changed).

## Acceptance criteria

- [x] Existing file + no `--write` → unified diff or "unchanged" note
- [x] Existing file + `--write` → diff shown before write; `--force` required to overwrite
- [x] No existing file → unchanged behavior (full proposed file)
- [x] `index --help` documents the diff behavior
- [x] New-file `--write` path unbroken

## Verification

- `go build ./...`, full `go test ./...`, `go vet`, `golangci-lint run ./...` (0 issues)
- Manual end-to-end against a scanned workspace: new-file preview, write, unchanged, diff, force-required, and diff-before-confirm all verified.

## Follow-up

Phase 2 (same scope, separate commit, pending review): extend the identical diff treatment to bulk `index repos`.