### PR TITLE
docs: update stale go 1.26.3 references to 1.26.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang        1.26.3
+golang        1.26.4
 golangci-lint 2.12.2
 goreleaser    2.16.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing to RepoKeeper.
 
 ## Development Setup
 
-- Go version: see `go.mod` (`go 1.26.3`).
+- Go version: see `go.mod` (`go 1.26.4`).
 - Run task targets without installing tools globally:
   - `go -C tools tool task --list`
 


### PR DESCRIPTION
Follow-up to #249 (Go 1.26.4 upgrade). Copilot's review flagged two stale `go 1.26.3` references that the dependency PR didn't catch (it only bumped the `go.mod` directives):

- `.tool-versions` — `golang 1.26.3 → 1.26.4`
- `CONTRIBUTING.md` — Go version note `1.26.3 → 1.26.4`

`grep -rn 1.26.3` across the repo now returns no matches (outside `go.sum`). No code or build changes.