### PR TITLE
fix(gitx): harden git/hg exec boundary (stdout/stderr, locale, flag injection)

### DIFF
--- a/internal/gitx/error_class.go
+++ b/internal/gitx/error_class.go
@@ -7,36 +7,19 @@ import (
 	"strings"
 )
 
-var (
-	// ErrAuthFailure marks authentication/authorization failures.
-	ErrAuthFailure = errors.New("git auth error")
-	// ErrNetworkFailure marks network/transport failures.
-	ErrNetworkFailure = errors.New("git network error")
-	// ErrCorruptRepo marks corrupt or invalid-repository failures.
-	ErrCorruptRepo = errors.New("git corrupt repository")
-	// ErrMissingRemoteRef marks missing upstream/ref/remote failures.
-	ErrMissingRemoteRef = errors.New("git missing remote")
-)
-
 // ClassifyError maps git/process errors into broad actionable categories.
+//
+// In production, git failures surface as *exec.ExitError (or a wrapped
+// error from GitRunner.Run carrying git's stderr text), never as a
+// sentinel error value, so classification is done entirely by matching
+// text in err.Error(). See GitRunner.Run for why that text is forced to
+// the C locale before it reaches here.
 func ClassifyError(err error) string {
 	if err == nil {
 		return ""
 	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return "timeout"
-	}
-	if errors.Is(err, ErrAuthFailure) {
-		return "auth"
-	}
-	if errors.Is(err, ErrNetworkFailure) {
-		return "network"
-	}
-	if errors.Is(err, ErrCorruptRepo) {
-		return "corrupt"
-	}
-	if errors.Is(err, ErrMissingRemoteRef) {
-		return "missing_remote"
 	}
 
 	msg := strings.ToLower(err.Error())

--- a/internal/gitx/error_class_test.go
+++ b/internal/gitx/error_class_test.go
@@ -18,10 +18,8 @@ func TestClassifyError(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: ""},
 		{name: "timeout", err: context.DeadlineExceeded, want: "timeout"},
-		{name: "auth sentinel", err: fmt.Errorf("wrapped: %w", gitx.ErrAuthFailure), want: "auth"},
-		{name: "network sentinel", err: fmt.Errorf("wrapped: %w", gitx.ErrNetworkFailure), want: "network"},
-		{name: "corrupt sentinel", err: fmt.Errorf("wrapped: %w", gitx.ErrCorruptRepo), want: "corrupt"},
-		{name: "missing remote sentinel", err: fmt.Errorf("wrapped: %w", gitx.ErrMissingRemoteRef), want: "missing_remote"},
+		{name: "canceled", err: context.Canceled, want: "timeout"},
+		{name: "wrapped timeout", err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded), want: "timeout"},
 		{name: "auth", err: errors.New("permission denied (publickey)"), want: "auth"},
 		{name: "network", err: errors.New("Could not resolve host: github.com"), want: "network"},
 		{name: "timeout text", err: errors.New("network timeout"), want: "timeout"},

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -311,7 +311,7 @@ func StashPop(ctx context.Context, r Runner, dir string) error {
 	return wrapRunError("git stash pop", out, err)
 }
 
-// Clone runs a clone operation. Branch is ignored for mirror clones.
+// ResetHard resets the worktree and index to HEAD, discarding local changes.
 func ResetHard(ctx context.Context, r Runner, dir string) error {
 	out, err := r.Run(ctx, dir, "reset", "--hard", "HEAD")
 	return wrapRunError("git reset --hard HEAD", out, err)
@@ -322,6 +322,7 @@ func CleanFD(ctx context.Context, r Runner, dir string) error {
 	return wrapRunError("git clean -f -d", out, err)
 }
 
+// Clone runs a clone operation. Branch is ignored for mirror clones.
 func Clone(ctx context.Context, r Runner, remoteURL, targetPath, branch string, mirror bool) error {
 	// remoteURL and targetPath are passed to git verbatim: leading/trailing
 	// whitespace is legal in local paths, and the flag-injection guard only

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -323,8 +323,10 @@ func CleanFD(ctx context.Context, r Runner, dir string) error {
 }
 
 func Clone(ctx context.Context, r Runner, remoteURL, targetPath, branch string, mirror bool) error {
-	remoteURL = strings.TrimSpace(remoteURL)
-	targetPath = strings.TrimSpace(targetPath)
+	// remoteURL and targetPath are passed to git verbatim: leading/trailing
+	// whitespace is legal in local paths, and the flag-injection guard only
+	// needs to reject values whose first byte is '-' (a leading space cannot be
+	// parsed as an option), so trimming would only corrupt valid inputs.
 	branch = strings.TrimSpace(branch)
 	if err := rejectFlagLike("remote URL", remoteURL); err != nil {
 		return err

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -4,8 +4,10 @@
 package gitx
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -17,7 +19,9 @@ import (
 // This interface allows mocking in tests.
 type Runner interface {
 	// Run executes a git command in the given directory and returns
-	// combined stdout/stderr output.
+	// trimmed stdout only. Any stderr text is folded into the returned
+	// error (see GitRunner.Run) and never appears in the returned string,
+	// so callers can safely parse the result as machine-readable output.
 	Run(ctx context.Context, dir string, args ...string) (string, error)
 }
 
@@ -37,8 +41,30 @@ func (g *GitRunner) Run(ctx context.Context, dir string, args ...string) (string
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
+	// Force the C locale so git's stderr text is stable, untranslated
+	// English: ClassifyError string-matches stderr, and on a non-English
+	// locale every classification would otherwise degrade to "unknown".
+	// A later duplicate key wins in cmd.Env, so this reliably overrides
+	// whatever locale the parent process is running under.
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+
+	// Capture stdout and stderr separately (mirrors internal/vcs's
+	// runCommand) instead of CombinedOutput(), which merges the two.
+	// An exit-0 git warning on stderr (e.g. an unknown gitconfig key)
+	// would otherwise corrupt callers that parse stdout as
+	// machine-readable output (IsRepo/IsBare/ParsePorcelainStatus).
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	out := strings.TrimSpace(stdout.String())
+	if err != nil {
+		if errText := strings.TrimSpace(stderr.String()); errText != "" {
+			return out, fmt.Errorf("%s: %w", errText, err)
+		}
+		return out, err
+	}
+	return out, nil
 }
 
 // IsRepo checks whether the given path is inside a git working tree.
@@ -239,13 +265,29 @@ func Push(ctx context.Context, r Runner, dir string) error {
 
 // SetUpstream configures the current local branch to track the given upstream.
 func SetUpstream(ctx context.Context, r Runner, dir, upstream, branch string) error {
-	out, err := r.Run(ctx, dir, "branch", "--set-upstream-to", strings.TrimSpace(upstream), strings.TrimSpace(branch))
+	upstream = strings.TrimSpace(upstream)
+	branch = strings.TrimSpace(branch)
+	if err := rejectFlagLike("upstream", upstream); err != nil {
+		return err
+	}
+	if err := rejectFlagLike("branch", branch); err != nil {
+		return err
+	}
+	out, err := r.Run(ctx, dir, "branch", "--set-upstream-to", upstream, branch)
 	return wrapRunError("git branch --set-upstream-to", out, err)
 }
 
 // SetRemoteURL updates the URL for a named remote.
 func SetRemoteURL(ctx context.Context, r Runner, dir, remote, remoteURL string) error {
-	out, err := r.Run(ctx, dir, "remote", "set-url", strings.TrimSpace(remote), strings.TrimSpace(remoteURL))
+	remote = strings.TrimSpace(remote)
+	remoteURL = strings.TrimSpace(remoteURL)
+	if err := rejectFlagLike("remote", remote); err != nil {
+		return err
+	}
+	if err := rejectFlagLike("remote URL", remoteURL); err != nil {
+		return err
+	}
+	out, err := r.Run(ctx, dir, "remote", "set-url", remote, remoteURL)
 	return wrapRunError("git remote set-url", out, err)
 }
 
@@ -281,15 +323,42 @@ func CleanFD(ctx context.Context, r Runner, dir string) error {
 }
 
 func Clone(ctx context.Context, r Runner, remoteURL, targetPath, branch string, mirror bool) error {
+	remoteURL = strings.TrimSpace(remoteURL)
+	targetPath = strings.TrimSpace(targetPath)
+	branch = strings.TrimSpace(branch)
+	if err := rejectFlagLike("remote URL", remoteURL); err != nil {
+		return err
+	}
+	if targetPath != "" {
+		if err := rejectFlagLike("target path", targetPath); err != nil {
+			return err
+		}
+	}
+
 	args := []string{"clone"}
 	if mirror {
 		args = append(args, "--mirror")
-	} else if strings.TrimSpace(branch) != "" {
-		args = append(args, "--branch", strings.TrimSpace(branch), "--single-branch")
+	} else if branch != "" {
+		if err := rejectFlagLike("branch", branch); err != nil {
+			return err
+		}
+		args = append(args, "--branch", branch, "--single-branch")
 	}
 	args = append(args, remoteURL, targetPath)
 	out, err := r.Run(ctx, "", args...)
 	return wrapRunError("git clone", out, err)
+}
+
+// rejectFlagLike rejects a positional argument (URL, path, ref, or remote
+// name) that begins with "-". git parses such values as an option rather
+// than a literal positional argument, so an attacker-controlled remote URL,
+// branch, or remote name beginning with "-" could otherwise smuggle
+// arbitrary flags into the git invocation.
+func rejectFlagLike(field, value string) error {
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("gitx: %s must not start with '-': %q", field, value)
+	}
+	return nil
 }
 
 func wrapRunError(op, output string, err error) error {

--- a/internal/gitx/gitx_test.go
+++ b/internal/gitx/gitx_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,6 +14,21 @@ import (
 	"github.com/skaphos/repokeeper/internal/gitx"
 	"github.com/skaphos/repokeeper/internal/model"
 )
+
+// writeFakeBin writes an executable POSIX shell script to a temp dir and
+// returns its path. Used to test GitRunner.Run's process plumbing (env,
+// stdout/stderr separation) without depending on real git's exact output.
+func writeFakeBin(script string) string {
+	if runtime.GOOS == "windows" {
+		Skip("fake git script uses POSIX shell")
+	}
+	tmpDir, err := os.MkdirTemp("", "gitx-fakebin")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { _ = os.RemoveAll(tmpDir) })
+	binPath := filepath.Join(tmpDir, "fake-git")
+	Expect(os.WriteFile(binPath, []byte(script), 0o755)).To(Succeed())
+	return binPath
+}
 
 var _ = Describe("GitRunner.Run", func() {
 	var runner *gitx.GitRunner
@@ -37,6 +53,69 @@ var _ = Describe("GitRunner.Run", func() {
 		cancel()
 		_, err := runner.Run(ctx, "", "version")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("does not merge stderr into stdout on a successful (exit-0) command", func() {
+		// Regression test: an exit-0 warning on stderr (e.g. an unknown
+		// gitconfig key) must not corrupt stdout, since callers like
+		// IsRepo/IsBare/ParsePorcelainStatus parse stdout as
+		// machine-readable output.
+		script := "#!/usr/bin/env sh\n" +
+			"echo 'true'\n" +
+			"echo 'warning: unknown config key foo.bar' 1>&2\n" +
+			"exit 0\n"
+		fakeGit := writeFakeBin(script)
+
+		fakeRunner := &gitx.GitRunner{GitBin: fakeGit}
+		out, err := fakeRunner.Run(context.Background(), "", "rev-parse", "--is-inside-work-tree")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("true"))
+		Expect(out).NotTo(ContainSubstring("warning"))
+	})
+
+	It("folds stderr text into the returned error without polluting stdout", func() {
+		script := "#!/usr/bin/env sh\n" +
+			"echo 'partial-stdout'\n" +
+			"echo 'fatal: boom' 1>&2\n" +
+			"exit 1\n"
+		fakeGit := writeFakeBin(script)
+
+		fakeRunner := &gitx.GitRunner{GitBin: fakeGit}
+		out, err := fakeRunner.Run(context.Background(), "", "status")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("fatal: boom"))
+		Expect(out).NotTo(ContainSubstring("fatal: boom"))
+	})
+
+	It("forces the C locale regardless of the parent process's locale", func() {
+		// Regression test: ClassifyError string-matches stderr text, so
+		// git must always be run with a stable, untranslated locale.
+		script := "#!/usr/bin/env sh\n" +
+			"echo \"LC_ALL=$LC_ALL LANG=$LANG\"\n" +
+			"exit 0\n"
+		fakeGit := writeFakeBin(script)
+
+		prevLCAll, hadLCAll := os.LookupEnv("LC_ALL")
+		prevLang, hadLang := os.LookupEnv("LANG")
+		Expect(os.Setenv("LC_ALL", "fr_FR.UTF-8")).To(Succeed())
+		Expect(os.Setenv("LANG", "fr_FR.UTF-8")).To(Succeed())
+		DeferCleanup(func() {
+			if hadLCAll {
+				_ = os.Setenv("LC_ALL", prevLCAll)
+			} else {
+				_ = os.Unsetenv("LC_ALL")
+			}
+			if hadLang {
+				_ = os.Setenv("LANG", prevLang)
+			} else {
+				_ = os.Unsetenv("LANG")
+			}
+		})
+
+		fakeRunner := &gitx.GitRunner{GitBin: fakeGit}
+		out, err := fakeRunner.Run(context.Background(), "", "version")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("LC_ALL=C LANG=C"))
 	})
 })
 

--- a/internal/gitx/mock_runner_test.go
+++ b/internal/gitx/mock_runner_test.go
@@ -22,7 +22,9 @@ type MockResponse struct {
 }
 
 func (m *MockRunner) Run(_ context.Context, dir string, args ...string) (string, error) {
-	m.LastArgs = args
+	// Copy args so LastArgs doesn't alias the caller's backing array; a caller
+	// that reuses/mutates its slice after Run returns must not change LastArgs.
+	m.LastArgs = append([]string(nil), args...)
 	key := dir + ":" + strings.Join(args, " ")
 	if resp, ok := m.Responses[key]; ok {
 		return resp.Output, resp.Err

--- a/internal/gitx/mock_runner_test.go
+++ b/internal/gitx/mock_runner_test.go
@@ -11,6 +11,9 @@ import (
 type MockRunner struct {
 	// Responses maps "dir:args" keys to (output, error) pairs.
 	Responses map[string]MockResponse
+	// LastArgs records the args of the most recent Run call so tests can assert
+	// the exact argv (e.g. that positional values are passed verbatim).
+	LastArgs []string
 }
 
 type MockResponse struct {
@@ -19,6 +22,7 @@ type MockResponse struct {
 }
 
 func (m *MockRunner) Run(_ context.Context, dir string, args ...string) (string, error) {
+	m.LastArgs = args
 	key := dir + ":" + strings.Join(args, " ")
 	if resp, ok := m.Responses[key]; ok {
 		return resp.Output, resp.Err

--- a/internal/gitx/parse.go
+++ b/internal/gitx/parse.go
@@ -46,6 +46,17 @@ type ForEachRefEntry struct {
 // ParseForEachRef parses the pipe-delimited output of:
 //
 //	git for-each-ref refs/heads --format="%(refname:short)|%(upstream:short)|%(upstream:track)|%(upstream:trackshort)"
+//
+// KNOWN LIMITATION (deferred, see PR description): "|" is technically a
+// legal character in a git ref name (git-check-ref-format does not
+// disallow it), so a branch such as "feat|x" can be misparsed here. The
+// correct fix — switching the --format string to a NUL ("%00") delimiter,
+// which cannot appear in a ref name — was prototyped but reverted because
+// it changes the exact argv git is invoked with, which breaks
+// internal/engine's mock-runner test fixtures that hardcode the current
+// pipe-delimited format string. internal/engine is outside this change's
+// file scope, so that fix needs a coordinated follow-up that updates both
+// packages together.
 func ParseForEachRef(output string) []ForEachRefEntry {
 	if output == "" {
 		return nil

--- a/internal/gitx/parse.go
+++ b/internal/gitx/parse.go
@@ -47,7 +47,7 @@ type ForEachRefEntry struct {
 //
 //	git for-each-ref refs/heads --format="%(refname:short)|%(upstream:short)|%(upstream:track)|%(upstream:trackshort)"
 //
-// KNOWN LIMITATION (deferred, see PR description): "|" is technically a
+// KNOWN LIMITATION (deferred): "|" is technically a
 // legal character in a git ref name (git-check-ref-format does not
 // disallow it), so a branch such as "feat|x" can be misparsed here. The
 // correct fix — switching the --format string to a NUL ("%00") delimiter,

--- a/internal/gitx/parse_test.go
+++ b/internal/gitx/parse_test.go
@@ -144,11 +144,10 @@ var _ = Describe("ParseForEachRef", func() {
 		Expect(entries).To(BeEmpty())
 	})
 
-	// KNOWN LIMITATION (see ParseForEachRef doc comment and PR
-	// description): "|" is technically legal in a git ref name, so a
-	// branch named "feat|x" is misparsed today. This is documented rather
-	// than fixed in this change because the correct fix (a NUL-delimited
-	// --format string) changes the exact git argv and breaks
+	// KNOWN LIMITATION (see ParseForEachRef doc comment): "|" is technically
+	// legal in a git ref name, so a branch named "feat|x" is misparsed today.
+	// This is documented rather than fixed in this change because the correct
+	// fix (a NUL-delimited --format string) changes the exact git argv and breaks
 	// internal/engine's mock-runner fixtures, which are outside this
 	// change's file scope.
 	It("documents that a literal pipe in a branch name is currently misparsed", func() {

--- a/internal/gitx/parse_test.go
+++ b/internal/gitx/parse_test.go
@@ -143,6 +143,21 @@ var _ = Describe("ParseForEachRef", func() {
 		entries := gitx.ParseForEachRef("")
 		Expect(entries).To(BeEmpty())
 	})
+
+	// KNOWN LIMITATION (see ParseForEachRef doc comment and PR
+	// description): "|" is technically legal in a git ref name, so a
+	// branch named "feat|x" is misparsed today. This is documented rather
+	// than fixed in this change because the correct fix (a NUL-delimited
+	// --format string) changes the exact git argv and breaks
+	// internal/engine's mock-runner fixtures, which are outside this
+	// change's file scope.
+	It("documents that a literal pipe in a branch name is currently misparsed", func() {
+		output := "feat|x|origin/feat|x|[ahead 1]|>"
+		entries := gitx.ParseForEachRef(output)
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Branch).To(Equal("feat"), "known-bad: the delimiter split mangles a branch name containing '|'")
+		Expect(entries[0].Branch).NotTo(Equal("feat|x"))
+	})
 })
 
 var _ = Describe("ParseRevListCount", func() {

--- a/internal/gitx/wrappers_test.go
+++ b/internal/gitx/wrappers_test.go
@@ -80,6 +80,20 @@ func TestSetUpstreamWrapper(t *testing.T) {
 	}
 }
 
+func TestSetUpstreamRejectsFlagLikeArgs(t *testing.T) {
+	// A malicious/malformed upstream or branch beginning with "-" must be
+	// rejected before it ever reaches git, where it would otherwise be
+	// parsed as a flag instead of a literal ref.
+	mock := &MockRunner{Responses: map[string]MockResponse{}}
+
+	if err := gitx.SetUpstream(context.Background(), mock, "/repo", "--upload-pack=evil", "main"); err == nil {
+		t.Fatal("expected error for flag-like upstream")
+	}
+	if err := gitx.SetUpstream(context.Background(), mock, "/repo", "origin/main", "-x"); err == nil {
+		t.Fatal("expected error for flag-like branch")
+	}
+}
+
 func TestSetRemoteURLWrapper(t *testing.T) {
 	mock := &MockRunner{Responses: map[string]MockResponse{
 		"/repo:remote set-url origin git@github.com:org/repo.git": {Output: ""},
@@ -93,6 +107,17 @@ func TestSetRemoteURLWrapper(t *testing.T) {
 	}}
 	if err := gitx.SetRemoteURL(context.Background(), mock, "/repo", "origin", "git@github.com:org/repo.git"); err == nil {
 		t.Fatal("expected set remote url failure")
+	}
+}
+
+func TestSetRemoteURLRejectsFlagLikeArgs(t *testing.T) {
+	mock := &MockRunner{Responses: map[string]MockResponse{}}
+
+	if err := gitx.SetRemoteURL(context.Background(), mock, "/repo", "-o", "git@github.com:org/repo.git"); err == nil {
+		t.Fatal("expected error for flag-like remote name")
+	}
+	if err := gitx.SetRemoteURL(context.Background(), mock, "/repo", "origin", "--upload-pack=evil"); err == nil {
+		t.Fatal("expected error for flag-like remote URL")
 	}
 }
 
@@ -132,5 +157,22 @@ func TestCloneWrapper(t *testing.T) {
 	}}
 	if err := gitx.Clone(context.Background(), mock, "git@github.com:org/repo.git", "/target", "", false); err == nil {
 		t.Fatal("expected clone error")
+	}
+}
+
+func TestCloneRejectsFlagLikeArgs(t *testing.T) {
+	// A remote URL, target path, or branch beginning with "-" must be
+	// rejected before it reaches git, where it would otherwise be parsed
+	// as a flag (e.g. "--upload-pack=...") instead of a literal argument.
+	mock := &MockRunner{Responses: map[string]MockResponse{}}
+
+	if err := gitx.Clone(context.Background(), mock, "--upload-pack=evil", "/target", "", false); err == nil {
+		t.Fatal("expected error for flag-like remote URL")
+	}
+	if err := gitx.Clone(context.Background(), mock, "git@github.com:org/repo.git", "-x", "", false); err == nil {
+		t.Fatal("expected error for flag-like target path")
+	}
+	if err := gitx.Clone(context.Background(), mock, "git@github.com:org/repo.git", "/target", "-x", false); err == nil {
+		t.Fatal("expected error for flag-like branch")
 	}
 }

--- a/internal/gitx/wrappers_test.go
+++ b/internal/gitx/wrappers_test.go
@@ -176,3 +176,27 @@ func TestCloneRejectsFlagLikeArgs(t *testing.T) {
 		t.Fatal("expected error for flag-like branch")
 	}
 }
+
+func TestCloneDoesNotTrimURLOrPath(t *testing.T) {
+	// Leading/trailing whitespace is legal in local paths, so the remote URL and
+	// target path must reach git verbatim; trimming would clone into the wrong
+	// directory. The flag guard only rejects values whose first byte is '-'.
+	spacedURL := " https://example.com/repo.git"
+	spacedPath := " /tmp/my repo "
+	mock := &MockRunner{Responses: map[string]MockResponse{}}
+	// The clone "fails" with an unexpected-call error because we do not register
+	// a response; we only care that the args reached the runner untouched.
+	_ = gitx.Clone(context.Background(), mock, spacedURL, spacedPath, "", false)
+
+	if len(mock.LastArgs) < 3 {
+		t.Fatalf("expected clone to reach the runner, got args %v", mock.LastArgs)
+	}
+	gotURL := mock.LastArgs[len(mock.LastArgs)-2]
+	gotPath := mock.LastArgs[len(mock.LastArgs)-1]
+	if gotURL != spacedURL {
+		t.Fatalf("remote URL passed to git = %q, want verbatim %q", gotURL, spacedURL)
+	}
+	if gotPath != spacedPath {
+		t.Fatalf("target path passed to git = %q, want verbatim %q", gotPath, spacedPath)
+	}
+}

--- a/internal/vcs/classify_test.go
+++ b/internal/vcs/classify_test.go
@@ -24,26 +24,6 @@ func TestGitErrorClassifier(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "auth failure",
-			err:      gitx.ErrAuthFailure,
-			expected: "auth",
-		},
-		{
-			name:     "network failure",
-			err:      gitx.ErrNetworkFailure,
-			expected: "network",
-		},
-		{
-			name:     "corrupt repo",
-			err:      gitx.ErrCorruptRepo,
-			expected: "corrupt",
-		},
-		{
-			name:     "missing remote ref",
-			err:      gitx.ErrMissingRemoteRef,
-			expected: "missing_remote",
-		},
-		{
 			name:     "context deadline exceeded",
 			err:      context.DeadlineExceeded,
 			expected: "timeout",
@@ -95,10 +75,6 @@ func TestGitErrorClassifierMatchesGitx(t *testing.T) {
 
 	testErrors := []error{
 		nil,
-		gitx.ErrAuthFailure,
-		gitx.ErrNetworkFailure,
-		gitx.ErrCorruptRepo,
-		gitx.ErrMissingRemoteRef,
 		context.DeadlineExceeded,
 		context.Canceled,
 		errors.New("permission denied"),

--- a/internal/vcs/command_runner.go
+++ b/internal/vcs/command_runner.go
@@ -27,3 +27,15 @@ func runCommand(ctx context.Context, dir, bin string, args ...string) (string, e
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }
+
+// rejectFlagLike rejects a positional argument (URL, path, or ref) that
+// begins with "-". hg (like git) parses such values as an option rather
+// than a literal positional argument, so an attacker-controlled remote
+// URL, branch, or path beginning with "-" could otherwise smuggle
+// arbitrary flags into the hg invocation.
+func rejectFlagLike(field, value string) error {
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("vcs: %s must not start with '-': %q", field, value)
+	}
+	return nil
+}

--- a/internal/vcs/hg_adapter.go
+++ b/internal/vcs/hg_adapter.go
@@ -93,8 +93,10 @@ func (h *HgAdapter) Clone(ctx context.Context, remoteURL, targetPath, branch str
 		return errUnsupportedForHg
 	}
 
-	remoteURL = strings.TrimSpace(remoteURL)
-	targetPath = strings.TrimSpace(targetPath)
+	// remoteURL and targetPath are passed to hg verbatim: leading/trailing
+	// whitespace is legal in local paths, and the flag-injection guard only
+	// needs to reject values whose first byte is '-', so trimming would only
+	// corrupt valid inputs.
 	branch = strings.TrimSpace(branch)
 	if err := rejectFlagLike("remote URL", remoteURL); err != nil {
 		return err

--- a/internal/vcs/hg_adapter.go
+++ b/internal/vcs/hg_adapter.go
@@ -89,12 +89,28 @@ func (h *HgAdapter) ResetHard(context.Context, string) error { return errUnsuppo
 func (h *HgAdapter) CleanFD(context.Context, string) error { return errUnsupportedForHg }
 
 func (h *HgAdapter) Clone(ctx context.Context, remoteURL, targetPath, branch string, mirror bool) error {
-	args := []string{"clone"}
-	if strings.TrimSpace(branch) != "" {
-		args = append(args, "--updaterev", strings.TrimSpace(branch))
-	}
 	if mirror {
 		return errUnsupportedForHg
+	}
+
+	remoteURL = strings.TrimSpace(remoteURL)
+	targetPath = strings.TrimSpace(targetPath)
+	branch = strings.TrimSpace(branch)
+	if err := rejectFlagLike("remote URL", remoteURL); err != nil {
+		return err
+	}
+	if targetPath != "" {
+		if err := rejectFlagLike("target path", targetPath); err != nil {
+			return err
+		}
+	}
+
+	args := []string{"clone"}
+	if branch != "" {
+		if err := rejectFlagLike("branch", branch); err != nil {
+			return err
+		}
+		args = append(args, "--updaterev", branch)
 	}
 	args = append(args, remoteURL, targetPath)
 	_, err := runCommand(ctx, "", "hg", args...)

--- a/internal/vcs/hg_adapter_test.go
+++ b/internal/vcs/hg_adapter_test.go
@@ -132,6 +132,46 @@ func TestHgAdapterUnsupportedOperations(t *testing.T) {
 	}
 }
 
+func TestHgAdapterCloneRejectsFlagLikeArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake hg script uses POSIX shell")
+	}
+	// A remote URL, target path, or branch beginning with "-" must be
+	// rejected before it reaches hg, where it would otherwise be parsed
+	// as a flag instead of a literal positional argument. A fake "hg"
+	// that unconditionally succeeds is put on PATH so that, if rejection
+	// did NOT happen, Clone would return a nil error; asserting a non-nil
+	// error here proves the value never reached exec.
+	tmp := t.TempDir()
+	hgPath := filepath.Join(tmp, "hg")
+	if err := os.WriteFile(hgPath, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake hg: %v", err)
+	}
+	prevPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", strings.Join([]string{tmp, prevPath}, ":")); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	defer func() { _ = os.Setenv("PATH", prevPath) }()
+
+	adapter := NewHgAdapter()
+
+	if err := adapter.Clone(context.Background(), "--config=evil", "/tmp/repo", "", false); err == nil {
+		t.Fatal("expected error for flag-like remote URL")
+	}
+	if err := adapter.Clone(context.Background(), "ssh://example/repo", "-x", "", false); err == nil {
+		t.Fatal("expected error for flag-like target path")
+	}
+	if err := adapter.Clone(context.Background(), "ssh://example/repo", "/tmp/repo", "-x", false); err == nil {
+		t.Fatal("expected error for flag-like branch")
+	}
+	// Sanity check: a non-flag-like clone against the fake hg does succeed,
+	// confirming the fake binary (not a PATH/lookup failure) is what would
+	// have made the above calls succeed had rejection not happened.
+	if err := adapter.Clone(context.Background(), "ssh://example/repo", "/tmp/repo", "default", false); err != nil {
+		t.Fatalf("expected clone with valid args to succeed against fake hg, got %v", err)
+	}
+}
+
 func TestHgAdapterIsRepoGracefullyHandlesCommandError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake hg script uses POSIX shell")


### PR DESCRIPTION
## Summary

Resolves a batch of verified code-review findings scoped to `internal/gitx/` and `internal/vcs/` (git/hg process-exec boundary). Findings 1, 2, and 5 are fully fixed with tests. Finding 4 is fixed. Finding 3 is intentionally deferred — see "Deferred" below.

## Findings fixed

**1. P1 — `gitx.go:40` `GitRunner.Run` merged stderr into parsed stdout via `CombinedOutput()`**
An exit-0 git warning (bad/unknown gitconfig key, broken-ref warning) on stderr could corrupt stdout parsing: `IsRepo`/`IsBare` would see `"warning...\ntrue" != "true"` and drop a real repo as not-a-repo; `ParsePorcelainStatus` would misread the warning line as a dirty-tree entry.
Fix: `GitRunner.Run` now captures stdout and stderr in separate `bytes.Buffer`s (mirrors `internal/vcs/command_runner.go`'s `runCommand`), returns stdout only, and folds stderr text into the returned error on failure.
Tests: `internal/gitx/gitx_test.go` — fake-binary regression tests asserting an exit-0 stderr warning does not appear in the returned stdout, and that stderr text is included in the error on failure.

**2. P1 — Missing flag-injection guard on positional git/hg args**
`gitx.go` `Clone` (~283), `SetUpstream` (~241), `SetRemoteURL` (~247), and `internal/vcs/hg_adapter.go` `Clone` (~91) passed URL/branch/remote values straight to git/hg. A value beginning with `-` would be parsed as a flag instead of a literal argument.
Fix: each now rejects (returns an error for) any positional URL/path/ref/remote-name argument beginning with `-`, before the value ever reaches `exec`.
**Decision — validation-only, no `--` separator:** the finding suggested both inserting `--` and rejecting leading-dash values. I implemented rejection only. Rejecting up front fully closes the injection vector (a rejected value never reaches git, so it can never be misparsed as a flag), making `--` redundant defense-in-depth. Crucially, validation-only keeps the exact argv unchanged for legitimate inputs, so it doesn't disturb `internal/engine`'s mock-runner test fixtures, which hardcode exact git argv strings and are outside this PR's file scope. I verified this empirically against real git and hg (see commit message) — `--` insertion was prototyped and confirmed to work, but was dropped in favor of the zero-blast-radius option.
Tests: table tests in `internal/gitx/wrappers_test.go` and `internal/vcs/hg_adapter_test.go` asserting flag-like upstream/branch/remote/URL/path values are rejected (the hg test uses a fake `hg` binary that unconditionally succeeds, to prove rejection happens before `exec`, not because the value it would have hit `hg` and failed for the same reason).

**4. P2 — `error_class.go:42` `ClassifyError` string-matches localized git stderr**
The runners set no `cmd.Env`, so git's stderr is emitted in the parent process's locale; on a non-English locale every classification degrades to `"unknown"`.
Fix: `GitRunner.Run` now sets `cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")` so git always emits stable, untranslated English stderr before it reaches `ClassifyError`. (Go's `exec.Cmd.Env` documents that the last value for a duplicate key wins, so this reliably overrides the parent locale — verified empirically.)
Tests: fake-binary test asserting `LC_ALL`/`LANG` are forced to `C` inside the child process regardless of the parent's locale.

**5. Dead code — `error_class.go:10-19` unreachable sentinels**
`ErrAuthFailure`/`ErrNetworkFailure`/`ErrCorruptRepo`/`ErrMissingRemoteRef` and their `errors.Is` branches (~29-40) are never returned in production; git failures surface as `*exec.ExitError`. A repo-wide grep confirmed the sentinels were referenced only by their own definitions and by two test files.
Fix: removed the sentinels and their `errors.Is` branches. Updated `internal/gitx/error_class_test.go` and `internal/vcs/classify_test.go` (both in scope) to drop the now-nonexistent sentinel cases; the string-heuristic classification paths they exercised remain fully tested.

## Deferred

**3. P2 — `parse.go:59` `ParseForEachRef` splits on `"|"`, which is legal in a git ref name**
A branch named e.g. `feat|x` loses its tracking info because `"|"` is not actually disallowed by `git-check-ref-format`.

I implemented and empirically verified the correct fix — switch `for-each-ref --format` to a NUL (`%00`) delimiter (git expands the literal 3-character escape `%00` in a `--format` string to a real NUL byte in its output; NUL can never appear in a valid ref name) — and it works. **I reverted it before committing**, because it necessarily changes the exact argv git is invoked with, and `internal/engine`'s mock-runner test fixtures hardcode the current pipe-delimited `--format` string in ~10 places (`engine_test.go`, `engine_internal_test.go`, `engine_actions_import_repair_internal_test.go`, `integration_test.go`). Landing the delimiter change here would leave `go test ./internal/engine/...` broken on `main` until a second, coordinated PR updates those fixtures — `internal/engine` is outside this PR's strict file scope (`internal/gitx/`, `internal/vcs/` only), so I could not make that fix in the same change.

I confirmed this by making the change locally and running the full repo test suite: `internal/gitx` and `internal/vcs` pass, but 6 specs in `internal/engine` fail because their mocked `for-each-ref` command string no longer matches.

Instead, this PR documents the limitation on `ParseForEachRef` (see doc comment) and adds a test that pins the current (known-bad) behavior for `"feat|x"`-style branch names, so it isn't silently forgotten.

**Recommended follow-up:** a PR that touches both `internal/gitx/parse.go` (switch to `%00`, already prototyped, see commit `docs(gitx): document deferred fix...` for the exact rationale) and `internal/engine`'s test fixtures (search for `for-each-ref --format=%(refname:short)|` and replace field separators with `\x00`) in the same change.

## Verification

```
export PATH="$GOROOT/bin:$PATH"
go build ./...                                                          # PASS
go vet ./internal/gitx/... ./internal/vcs/...                           # PASS
go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./internal/gitx/... ./internal/vcs/...   # PASS, no findings
go test ./internal/gitx/... ./internal/vcs/...                          # PASS
go test -race ./internal/gitx/... ./internal/vcs/...                    # PASS
```

Also ran `go build ./... && go vet ./... && go test ./...` across the whole repo (not required by scope, but confirms no unintended fallout from findings 1/2/4/5): all packages pass, including `internal/engine`, since finding 3 was deferred rather than landed.

## Scope note

All changes are confined to `internal/gitx/` and `internal/vcs/` per the assigned file scope. No exported symbols were added to any other package, and no other package's public API changed.