### PR TITLE
fix(mcp): registry locking, mutation safety gates, and config-install data-loss fixes

### DIFF
--- a/internal/mcpinstall/claude.go
+++ b/internal/mcpinstall/claude.go
@@ -15,6 +15,12 @@ import (
 // adapters use the same name.
 const repokeeperKey = "repokeeper"
 
+// newConfigFileMode is the permission mode used when creating a config file
+// that does not yet exist. These files can hold MCP server env/secrets, so
+// they are created owner-only (0o600) rather than world-readable. Existing
+// files keep their own mode — WriteAtomic preserves it.
+const newConfigFileMode fs.FileMode = 0o600
+
 type claudeAdapter struct{}
 
 func init() {
@@ -125,7 +131,7 @@ func (a *claudeAdapter) WriteEntry(path string, e Entry) error {
 	}
 	servers[repokeeperKey] = claudeServer{Command: e.Command, Args: e.Args}
 	doc["mcpServers"] = servers
-	return writeJSONDoc(path, doc, 0o644)
+	return writeJSONDoc(path, doc, newConfigFileMode)
 }
 
 func (a *claudeAdapter) RemoveEntry(path string) (bool, error) {
@@ -149,7 +155,7 @@ func (a *claudeAdapter) RemoveEntry(path string) (bool, error) {
 	}
 	delete(servers, repokeeperKey)
 	doc["mcpServers"] = servers
-	return true, writeJSONDoc(path, doc, 0o644)
+	return true, writeJSONDoc(path, doc, newConfigFileMode)
 }
 
 // readJSONDoc parses the file at path as a top-level JSON object. A

--- a/internal/mcpinstall/codex.go
+++ b/internal/mcpinstall/codex.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -92,6 +93,10 @@ func (a *codexAdapter) ReadEntry(path string) (Entry, bool, error) {
 }
 
 func (a *codexAdapter) WriteEntry(path string, e Entry) error {
+	// Guard before any rewrite so a commented config is never clobbered.
+	if err := refuseIfTOMLComments(path); err != nil {
+		return err
+	}
 	doc, err := readTOMLDoc(path)
 	if err != nil {
 		return err
@@ -106,7 +111,7 @@ func (a *codexAdapter) WriteEntry(path string, e Entry) error {
 	// Use a typed struct so TOML serializes the table in a canonical form.
 	servers[repokeeperKey] = codexServer{Command: e.Command, Args: e.Args}
 	doc["mcp_servers"] = servers
-	return writeTOMLDoc(path, doc, 0o644)
+	return writeTOMLDoc(path, doc, newConfigFileMode)
 }
 
 func (a *codexAdapter) RemoveEntry(path string) (bool, error) {
@@ -124,9 +129,14 @@ func (a *codexAdapter) RemoveEntry(path string) (bool, error) {
 	if _, ok := servers[repokeeperKey]; !ok {
 		return false, nil
 	}
+	// An entry exists and will be rewritten out; guard comments only now,
+	// since a no-op remove (handled above) never rewrites the file.
+	if err := refuseIfTOMLComments(path); err != nil {
+		return false, err
+	}
 	delete(servers, repokeeperKey)
 	doc["mcp_servers"] = servers
-	return true, writeTOMLDoc(path, doc, 0o644)
+	return true, writeTOMLDoc(path, doc, newConfigFileMode)
 }
 
 // codexServersMap returns the mcp_servers table from doc, or nil if
@@ -166,6 +176,95 @@ func readTOMLDoc(path string) (map[string]any, error) {
 		doc = map[string]any{}
 	}
 	return doc, nil
+}
+
+// refuseIfTOMLComments returns an error if the TOML file at path contains
+// comments.
+//
+// Design note (data-loss avoidance): these adapters edit config by reading the
+// file into a bare map[string]any, mutating it, and re-marshaling. go-toml/v2
+// has no comment trivia on that map, so every round-trip erases ALL comments
+// in the user's hand-maintained Codex/Grok config.toml. A lossless in-place
+// TOML edit that preserves comments is not feasible with the current library
+// within this change's scope, so we take the conservative fail-safe path:
+// detect any comment and refuse to rewrite the file, directing the user to
+// edit it manually. Non-existent/empty files (and files with no comments) are
+// written normally. tomlHasComments biases toward detection, so at worst we
+// refuse a safe write — we never silently destroy comments.
+func refuseIfTOMLComments(path string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if tomlHasComments(raw) {
+		return fmt.Errorf("refusing to rewrite %q: it contains comments this installer cannot preserve; add or remove the [mcp_servers.%s] entry manually", path, repokeeperKey)
+	}
+	return nil
+}
+
+// tomlHasComments reports whether raw contains a TOML comment (an unquoted
+// '#'). It skips over basic ("..."), literal ('...'), and multi-line
+// ("""...""" / '''...''') strings so a '#' inside a string value is not
+// mistaken for a comment. Malformed/unterminated strings cause the remainder
+// to be treated as string content; such input is rejected earlier by
+// readTOMLDoc's parse, so it never reaches a write.
+func tomlHasComments(raw []byte) bool {
+	s := string(raw)
+	for i := 0; i < len(s); {
+		switch {
+		case s[i] == '#':
+			return true
+		case s[i] == '"':
+			if strings.HasPrefix(s[i:], `"""`) {
+				i = skipTOMLDelim(s, i+3, `"""`)
+			} else {
+				i = skipTOMLSingleLine(s, i+1, '"', true)
+			}
+		case s[i] == '\'':
+			if strings.HasPrefix(s[i:], `'''`) {
+				i = skipTOMLDelim(s, i+3, `'''`)
+			} else {
+				i = skipTOMLSingleLine(s, i+1, '\'', false)
+			}
+		default:
+			i++
+		}
+	}
+	return false
+}
+
+// skipTOMLSingleLine advances past a single-line string body starting at i
+// (just after the opening quote) and returns the index after the closing
+// quote. A single-line string never spans a newline; if one is reached the
+// string is treated as ended there. When escapes is true (basic strings), a
+// backslash escapes the next byte.
+func skipTOMLSingleLine(s string, i int, quote byte, escapes bool) int {
+	for i < len(s) {
+		switch {
+		case escapes && s[i] == '\\':
+			i += 2
+		case s[i] == '\n':
+			return i
+		case s[i] == quote:
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+// skipTOMLDelim returns the index just past the next occurrence of delim at or
+// after i, or len(s) if delim does not occur again (unterminated multi-line
+// string).
+func skipTOMLDelim(s string, i int, delim string) int {
+	if idx := strings.Index(s[i:], delim); idx >= 0 {
+		return i + idx + len(delim)
+	}
+	return len(s)
 }
 
 // writeTOMLDoc marshals doc as TOML and writes atomically, creating

--- a/internal/mcpinstall/codex.go
+++ b/internal/mcpinstall/codex.go
@@ -206,24 +206,24 @@ func refuseIfTOMLComments(path string) error {
 }
 
 // tomlHasComments reports whether raw contains a TOML comment (an unquoted
-// '#'). It skips over basic ("..."), literal ('...'), and multi-line
-// ("""...""" / '''...''') strings so a '#' inside a string value is not
+// '#'). It skips over basic ("...") and literal ('...') strings, both
+// single-line and triple-quoted, so a '#' inside a string value is not
 // mistaken for a comment. Malformed/unterminated strings cause the remainder
 // to be treated as string content; such input is rejected earlier by
 // readTOMLDoc's parse, so it never reaches a write.
 func tomlHasComments(raw []byte) bool {
 	s := string(raw)
 	for i := 0; i < len(s); {
-		switch {
-		case s[i] == '#':
+		switch s[i] {
+		case '#':
 			return true
-		case s[i] == '"':
+		case '"':
 			if strings.HasPrefix(s[i:], `"""`) {
 				i = skipTOMLDelim(s, i+3, `"""`)
 			} else {
 				i = skipTOMLSingleLine(s, i+1, '"', true)
 			}
-		case s[i] == '\'':
+		case '\'':
 			if strings.HasPrefix(s[i:], `'''`) {
 				i = skipTOMLDelim(s, i+3, `'''`)
 			} else {

--- a/internal/mcpinstall/comment_guard_test.go
+++ b/internal/mcpinstall/comment_guard_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+package mcpinstall
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// --- tomlHasComments unit tests (finding 6) ---
+
+func TestTomlHasComments(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"no comment", "command = '/bin/repokeeper'\nargs = ['mcp']\n", false},
+		{"leading comment", "# hand-maintained\ncommand = 'x'\n", true},
+		{"trailing comment", "command = 'x' # inline note\n", true},
+		{"hash inside basic string", `command = "a#b"` + "\n", false},
+		{"hash inside literal string", `command = 'a#b'` + "\n", false},
+		{"hash after literal string closes", `command = 'x' #c` + "\n", true},
+		{"escaped quote then hash in string", `command = "a\"#b"` + "\n", false},
+		{"multiline basic string with hash", "x = \"\"\"\nline # not a comment\n\"\"\"\n", false},
+		{"multiline literal string with hash", "x = '''\nline # not a comment\n'''\ny = 1\n", false},
+		{"comment after multiline string", "x = \"\"\"a\"\"\" # real\n", true},
+		{"hash at end of file no newline", "command = 'x'\n#tail", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tomlHasComments([]byte(tc.in)); got != tc.want {
+				t.Fatalf("tomlHasComments(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// writeTemp writes content to a fresh temp file and returns its path.
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	return path
+}
+
+// --- codex/grok WriteEntry refuses to clobber comments (finding 6) ---
+
+func TestCodexWriteEntryRefusesCommentedFile(t *testing.T) {
+	t.Parallel()
+	original := "# user notes, please keep\nmodel = 'gpt-4'\n"
+	path := writeTemp(t, "config.toml", original)
+	a := &codexAdapter{}
+	err := a.WriteEntry(path, Entry{Command: "/bin/repokeeper", Args: []string{"mcp"}, Enabled: true})
+	if err == nil {
+		t.Fatal("expected WriteEntry to refuse a commented file")
+	}
+	if !strings.Contains(err.Error(), "comments") {
+		t.Fatalf("expected a comment-preservation error, got: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	if string(raw) != original {
+		t.Fatalf("commented file was modified despite refusal:\n%s", raw)
+	}
+}
+
+func TestGrokWriteEntryRefusesCommentedFile(t *testing.T) {
+	t.Parallel()
+	original := "# grok config, hand tuned\napi_key = 'secret'\n"
+	path := writeTemp(t, "config.toml", original)
+	a := &grokAdapter{}
+	err := a.WriteEntry(path, Entry{Command: "/bin/repokeeper", Args: []string{"mcp"}, Enabled: true})
+	if err == nil {
+		t.Fatal("expected WriteEntry to refuse a commented file")
+	}
+	raw, _ := os.ReadFile(path)
+	if string(raw) != original {
+		t.Fatalf("commented file was modified despite refusal:\n%s", raw)
+	}
+}
+
+// A file with no comments is still written normally.
+func TestCodexWriteEntryAllowsUncommentedFile(t *testing.T) {
+	t.Parallel()
+	path := writeTemp(t, "config.toml", "model = 'gpt-4'\n")
+	a := &codexAdapter{}
+	if err := a.WriteEntry(path, Entry{Command: "/bin/repokeeper", Args: []string{"mcp"}, Enabled: true}); err != nil {
+		t.Fatalf("unexpected error writing uncommented file: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "[mcp_servers.repokeeper]") {
+		t.Fatalf("entry not written: %s", raw)
+	}
+}
+
+// --- RemoveEntry comment handling (finding 6) ---
+
+// A no-op remove (entry absent) must NOT refuse just because the file has
+// comments, since no rewrite happens.
+func TestCodexRemoveEntryAbsentCommentedFileSucceeds(t *testing.T) {
+	t.Parallel()
+	original := "# just comments and unrelated config\nmodel = 'gpt-4'\n"
+	path := writeTemp(t, "config.toml", original)
+	a := &codexAdapter{}
+	removed, err := a.RemoveEntry(path)
+	if err != nil {
+		t.Fatalf("no-op remove on commented file should succeed, got: %v", err)
+	}
+	if removed {
+		t.Fatal("expected removed=false when entry absent")
+	}
+	raw, _ := os.ReadFile(path)
+	if string(raw) != original {
+		t.Fatalf("file changed on no-op remove:\n%s", raw)
+	}
+}
+
+// Removing a present entry from a commented file must refuse rather than
+// silently drop the comments.
+func TestCodexRemoveEntryPresentCommentedFileRefuses(t *testing.T) {
+	t.Parallel()
+	original := "# keep me\n[mcp_servers.repokeeper]\ncommand = '/bin/repokeeper'\nargs = ['mcp']\n"
+	path := writeTemp(t, "config.toml", original)
+	a := &codexAdapter{}
+	_, err := a.RemoveEntry(path)
+	if err == nil {
+		t.Fatal("expected RemoveEntry to refuse a commented file with a present entry")
+	}
+	raw, _ := os.ReadFile(path)
+	if string(raw) != original {
+		t.Fatalf("commented file was modified despite refusal:\n%s", raw)
+	}
+}
+
+// --- new config files are created 0o600 (finding 7) ---
+
+func TestNewConfigFilesAreOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes not meaningful on windows")
+	}
+	entry := Entry{Command: "/bin/repokeeper", Args: []string{"mcp"}, Enabled: true}
+	cases := []struct {
+		name    string
+		file    string
+		writeFn func(path string, e Entry) error
+	}{
+		{"codex", "config.toml", (&codexAdapter{}).WriteEntry},
+		{"grok", "config.toml", (&grokAdapter{}).WriteEntry},
+		{"claude", ".claude.json", (&claudeAdapter{}).WriteEntry},
+		{"opencode", "opencode.json", (&opencodeAdapter{}).WriteEntry},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), tc.file)
+			if err := tc.writeFn(path, entry); err != nil {
+				t.Fatalf("WriteEntry: %v", err)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat: %v", err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("new %s config mode = %o, want 0600", tc.name, got)
+			}
+		})
+	}
+}

--- a/internal/mcpinstall/comment_guard_test.go
+++ b/internal/mcpinstall/comment_guard_test.go
@@ -51,6 +51,17 @@ func writeTemp(t *testing.T, name, content string) string {
 	return path
 }
 
+// mustReadFile reads path and fails the test if the read errors, so a failed
+// read can't masquerade as an unexpected file content in the assertions below.
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return raw
+}
+
 // --- codex/grok WriteEntry refuses to clobber comments (finding 6) ---
 
 func TestCodexWriteEntryRefusesCommentedFile(t *testing.T) {
@@ -65,7 +76,7 @@ func TestCodexWriteEntryRefusesCommentedFile(t *testing.T) {
 	if !strings.Contains(err.Error(), "comments") {
 		t.Fatalf("expected a comment-preservation error, got: %v", err)
 	}
-	raw, _ := os.ReadFile(path)
+	raw := mustReadFile(t, path)
 	if string(raw) != original {
 		t.Fatalf("commented file was modified despite refusal:\n%s", raw)
 	}
@@ -80,7 +91,7 @@ func TestGrokWriteEntryRefusesCommentedFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected WriteEntry to refuse a commented file")
 	}
-	raw, _ := os.ReadFile(path)
+	raw := mustReadFile(t, path)
 	if string(raw) != original {
 		t.Fatalf("commented file was modified despite refusal:\n%s", raw)
 	}
@@ -94,7 +105,7 @@ func TestCodexWriteEntryAllowsUncommentedFile(t *testing.T) {
 	if err := a.WriteEntry(path, Entry{Command: "/bin/repokeeper", Args: []string{"mcp"}, Enabled: true}); err != nil {
 		t.Fatalf("unexpected error writing uncommented file: %v", err)
 	}
-	raw, _ := os.ReadFile(path)
+	raw := mustReadFile(t, path)
 	if !strings.Contains(string(raw), "[mcp_servers.repokeeper]") {
 		t.Fatalf("entry not written: %s", raw)
 	}
@@ -116,7 +127,7 @@ func TestCodexRemoveEntryAbsentCommentedFileSucceeds(t *testing.T) {
 	if removed {
 		t.Fatal("expected removed=false when entry absent")
 	}
-	raw, _ := os.ReadFile(path)
+	raw := mustReadFile(t, path)
 	if string(raw) != original {
 		t.Fatalf("file changed on no-op remove:\n%s", raw)
 	}
@@ -133,7 +144,7 @@ func TestCodexRemoveEntryPresentCommentedFileRefuses(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected RemoveEntry to refuse a commented file with a present entry")
 	}
-	raw, _ := os.ReadFile(path)
+	raw := mustReadFile(t, path)
 	if string(raw) != original {
 		t.Fatalf("commented file was modified despite refusal:\n%s", raw)
 	}

--- a/internal/mcpinstall/grok.go
+++ b/internal/mcpinstall/grok.go
@@ -115,6 +115,9 @@ func (a *grokAdapter) ReadEntry(path string) (Entry, bool, error) {
 }
 
 func (a *grokAdapter) WriteEntry(path string, e Entry) error {
+	if err := refuseIfTOMLComments(path); err != nil {
+		return err
+	}
 	doc, err := readTOMLDoc(path)
 	if err != nil {
 		return err
@@ -132,7 +135,7 @@ func (a *grokAdapter) WriteEntry(path string, e Entry) error {
 		Enabled: e.Enabled,
 	}
 	doc["mcp_servers"] = servers
-	return writeTOMLDoc(path, doc, 0o644)
+	return writeTOMLDoc(path, doc, newConfigFileMode)
 }
 
 func (a *grokAdapter) RemoveEntry(path string) (bool, error) {
@@ -150,9 +153,14 @@ func (a *grokAdapter) RemoveEntry(path string) (bool, error) {
 	if _, ok := servers[repokeeperKey]; !ok {
 		return false, nil
 	}
+	// An entry exists and will be rewritten out; guard comments only now,
+	// since a no-op remove (handled above) never rewrites the file.
+	if err := refuseIfTOMLComments(path); err != nil {
+		return false, err
+	}
 	delete(servers, repokeeperKey)
 	doc["mcp_servers"] = servers
-	return true, writeTOMLDoc(path, doc, 0o644)
+	return true, writeTOMLDoc(path, doc, newConfigFileMode)
 }
 
 // grokServersMap returns the mcp_servers table from doc, or nil if

--- a/internal/mcpinstall/opencode.go
+++ b/internal/mcpinstall/opencode.go
@@ -154,7 +154,7 @@ func (a *opencodeAdapter) WriteEntry(path string, e Entry) error {
 	argv := append([]string{e.Command}, e.Args...)
 	servers[repokeeperKey] = opencodeServer{Type: "local", Command: argv, Enabled: e.Enabled}
 	doc["mcp"] = servers
-	return writeJSONDoc(path, doc, 0o644)
+	return writeJSONDoc(path, doc, newConfigFileMode)
 }
 
 func (a *opencodeAdapter) RemoveEntry(path string) (bool, error) {
@@ -177,7 +177,7 @@ func (a *opencodeAdapter) RemoveEntry(path string) (bool, error) {
 	}
 	delete(servers, repokeeperKey)
 	doc["mcp"] = servers
-	return true, writeJSONDoc(path, doc, 0o644)
+	return true, writeJSONDoc(path, doc, newConfigFileMode)
 }
 
 // opencodeServersMap returns the mcp object from doc, or nil if no mcp

--- a/internal/mcpserver/engine.go
+++ b/internal/mcpserver/engine.go
@@ -11,12 +11,11 @@ import (
 	"github.com/skaphos/repokeeper/internal/engine"
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/registry"
-	"github.com/skaphos/repokeeper/internal/vcs"
 )
 
 // EngineAPI abstracts engine operations so the MCP server can be tested
 // without a concrete engine or live repositories. Extends the TUI pattern
-// with Scan and Adapter accessors needed by MCP mutation tools.
+// with a Scan accessor needed by MCP mutation tools.
 type EngineAPI interface {
 	Status(ctx context.Context, opts engine.StatusOptions) (*model.StatusReport, error)
 	Sync(ctx context.Context, opts engine.SyncOptions) ([]engine.SyncResult, error)
@@ -28,14 +27,11 @@ type EngineAPI interface {
 		onComplete engine.SyncResultCallback,
 	) ([]engine.SyncResult, error)
 	InspectRepo(ctx context.Context, path string) (*model.RepoStatus, error)
-	RepairUpstream(ctx context.Context, repoID, cfgPath string) (engine.RepairUpstreamResult, error)
-	ResetRepo(ctx context.Context, repoID, cfgPath string) error
 	DeleteRepo(ctx context.Context, repoID, cfgPath string, deleteFiles bool) error
 	CloneAndRegister(ctx context.Context, remoteURL, targetPath, cfgPath string, mirror bool) error
 	Scan(ctx context.Context, opts engine.ScanOptions) ([]model.RepoStatus, error)
 	Registry() *registry.Registry
 	Config() *config.Config
-	Adapter() vcs.Adapter
 }
 
 // Compile-time check: *engine.Engine must satisfy EngineAPI.

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,7 +20,6 @@ import (
 	"github.com/skaphos/repokeeper/internal/mcpserver"
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/registry"
-	"github.com/skaphos/repokeeper/internal/vcs"
 )
 
 // --- mock engine ---
@@ -102,10 +102,6 @@ func (e *mockEngine) InspectRepo(_ context.Context, path string) (*model.RepoSta
 		},
 	}, nil
 }
-func (e *mockEngine) RepairUpstream(_ context.Context, _, _ string) (engine.RepairUpstreamResult, error) {
-	return engine.RepairUpstreamResult{}, nil
-}
-func (e *mockEngine) ResetRepo(_ context.Context, _, _ string) error { return nil }
 func (e *mockEngine) DeleteRepo(_ context.Context, _, _ string, _ bool) error {
 	e.deleteRepoCalled = true
 	return e.deleteRepoErr
@@ -125,7 +121,6 @@ func (e *mockEngine) Scan(_ context.Context, _ engine.ScanOptions) ([]model.Repo
 }
 func (e *mockEngine) Registry() *registry.Registry { return e.reg }
 func (e *mockEngine) Config() *config.Config       { return e.cfg }
-func (e *mockEngine) Adapter() vcs.Adapter         { return nil }
 
 var _ mcpserver.EngineAPI = (*mockEngine)(nil)
 
@@ -1059,6 +1054,17 @@ var _ = Describe("MCPServer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeTrue())
 		})
+
+		// Finding 2: an unknown/typo filter must be rejected in the handler,
+		// not passed to the engine (where it fails open and syncs ALL repos).
+		It("rejects an unknown filter", func() {
+			result, err := callTool(srv, "plan_sync", map[string]any{
+				"filter": "drity",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeTrue())
+			Expect(string(resultJSON(result))).To(ContainSubstring("invalid filter"))
+		})
 	})
 
 	Describe("execute_sync", func() {
@@ -1141,6 +1147,20 @@ var _ = Describe("MCPServer", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeTrue())
+		})
+
+		// Finding 2: execute_sync{filter:"drity",force:true,push_local:true}
+		// must be rejected rather than force-push every repo.
+		It("rejects an unknown filter even with confirm=true", func() {
+			result, err := callTool(srv, "execute_sync", map[string]any{
+				"confirm":    true,
+				"filter":     "drity",
+				"force":      true,
+				"push_local": true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeTrue())
+			Expect(string(resultJSON(result))).To(ContainSubstring("invalid filter"))
 		})
 	})
 
@@ -1289,6 +1309,89 @@ var _ = Describe("MCPServer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeTrue())
 		})
+
+		// Finding 5: schema advertises "repo_id or absolute path"; removal
+		// must route through resolveRepo so an absolute checkout path works.
+		It("removes a repo by absolute path", func() {
+			result, err := callTool(srv, "remove_repository", map[string]any{
+				"repo": "/home/user/repos/beta",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+			Expect(eng.deleteRepoCalled).To(BeTrue())
+
+			var resp map[string]any
+			Expect(json.Unmarshal(resultJSON(result), &resp)).To(Succeed())
+			Expect(resp["repo_id"]).To(Equal("github.com/example/beta"))
+		})
+
+		It("returns error for an unknown repo before touching the engine", func() {
+			result, err := callTool(srv, "remove_repository", map[string]any{
+				"repo": "/home/user/repos/does-not-exist",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeTrue())
+			Expect(eng.deleteRepoCalled).To(BeFalse())
+		})
+
+		// Finding 1: delete_files performs permanent working-tree deletion and
+		// must be gated behind a strict-bool confirm=true, mirroring execute_sync.
+		Describe("delete_files safety gate", func() {
+			It("rejects delete_files=true without confirm", func() {
+				result, err := callTool(srv, "remove_repository", map[string]any{
+					"repo":         "github.com/example/alpha",
+					"delete_files": true,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsError).To(BeTrue())
+				Expect(eng.deleteRepoCalled).To(BeFalse())
+				Expect(string(resultJSON(result))).To(ContainSubstring(`required argument "confirm" not found`))
+			})
+
+			It("rejects delete_files=true with confirm=false", func() {
+				result, err := callTool(srv, "remove_repository", map[string]any{
+					"repo":         "github.com/example/alpha",
+					"delete_files": true,
+					"confirm":      false,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsError).To(BeTrue())
+				Expect(eng.deleteRepoCalled).To(BeFalse())
+				Expect(string(resultJSON(result))).To(ContainSubstring("safety gate"))
+			})
+
+			It("rejects a non-boolean confirm", func() {
+				result, err := callTool(srv, "remove_repository", map[string]any{
+					"repo":         "github.com/example/alpha",
+					"delete_files": true,
+					"confirm":      "true",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsError).To(BeTrue())
+				Expect(eng.deleteRepoCalled).To(BeFalse())
+				Expect(string(resultJSON(result))).To(ContainSubstring(`argument "confirm" must be a boolean`))
+			})
+
+			It("proceeds with delete_files=true and confirm=true", func() {
+				result, err := callTool(srv, "remove_repository", map[string]any{
+					"repo":         "github.com/example/alpha",
+					"delete_files": true,
+					"confirm":      true,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsError).To(BeFalse())
+				Expect(eng.deleteRepoCalled).To(BeTrue())
+			})
+
+			It("does not require confirm for tracking-only removal", func() {
+				result, err := callTool(srv, "remove_repository", map[string]any{
+					"repo": "github.com/example/alpha",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsError).To(BeFalse())
+				Expect(eng.deleteRepoCalled).To(BeTrue())
+			})
+		})
 	})
 })
 
@@ -1315,6 +1418,118 @@ var _ = Describe("resolveRepo", Ordered, func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.IsError).To(BeFalse())
+	})
+})
+
+// registryWithDuplicateRepoID returns a registry where one repo_id maps to two
+// distinct local checkouts — the ambiguity case from finding 4.
+func registryWithDuplicateRepoID() *registry.Registry {
+	return &registry.Registry{
+		UpdatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		Entries: []registry.Entry{
+			{
+				RepoID:   "github.com/example/dup",
+				Path:     "/home/user/repos/dup-a",
+				Type:     "checkout",
+				Status:   registry.StatusPresent,
+				LastSeen: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			},
+			{
+				RepoID:   "github.com/example/dup",
+				Path:     "/home/user/repos/dup-b",
+				Type:     "checkout",
+				Status:   registry.StatusPresent,
+				LastSeen: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+}
+
+// Finding 4: resolveRepo must reject an ambiguous repo_id rather than silently
+// act on an arbitrary checkout; an absolute path still disambiguates.
+var _ = Describe("resolveRepo ambiguity", func() {
+	var (
+		eng *mockEngine
+		srv *mcpserver.MCPServer
+	)
+
+	BeforeEach(func() {
+		eng = &mockEngine{cfg: newTestConfig(), reg: registryWithDuplicateRepoID()}
+		srv = mcpserver.New(eng, "/tmp/ambiguous.yaml", "0.1.0-test", nil)
+	})
+
+	It("errors on set_labels for an ambiguous repo_id", func() {
+		result, err := callTool(srv, "set_labels", map[string]any{
+			"repo": "github.com/example/dup",
+			"set":  map[string]any{"tier": "critical"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsError).To(BeTrue())
+		Expect(string(resultJSON(result))).To(ContainSubstring("ambiguous"))
+	})
+
+	It("errors on get_repository_context for an ambiguous repo_id", func() {
+		result, err := callTool(srv, "get_repository_context", map[string]any{
+			"repo": "github.com/example/dup",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsError).To(BeTrue())
+		Expect(string(resultJSON(result))).To(ContainSubstring("ambiguous"))
+	})
+
+	It("disambiguates via absolute path", func() {
+		result, err := callTool(srv, "set_labels", map[string]any{
+			"repo": "/home/user/repos/dup-b",
+			"set":  map[string]any{"tier": "critical"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsError).To(BeFalse())
+		Expect(eng.reg.Entries[1].Labels).To(HaveKeyWithValue("tier", "critical"))
+		Expect(eng.reg.Entries[0].Labels).To(BeNil())
+	})
+})
+
+// Finding 3: ServeStdio dispatches tool calls on a concurrent worker pool and
+// handlers mutate/iterate the shared registry lock-free. Without the
+// server-level mutex two overlapping calls trigger a fatal concurrent
+// map/slice access. This spec drives many overlapping handlers and must pass
+// cleanly under `go test -race`; before the serialization fix it faults.
+var _ = Describe("concurrent tool access", func() {
+	It("serializes overlapping registry mutations and reads", func() {
+		eng := &mockEngine{cfg: newTestConfig(), reg: newTestRegistry()}
+		eng.scanResult = []model.RepoStatus{
+			{RepoID: "github.com/example/alpha", Path: "/home/user/repos/alpha"},
+		}
+		srv := mcpserver.New(eng, "/tmp/concurrent.yaml", "0.1.0-test", nil)
+
+		const workers = 8
+		const iterations = 25
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for w := 0; w < workers; w++ {
+			go func(w int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				for i := 0; i < iterations; i++ {
+					switch w % 4 {
+					case 0:
+						_, _ = callTool(srv, "set_labels", map[string]any{
+							"repo": "github.com/example/alpha",
+							"set":  map[string]any{"k": fmt.Sprintf("%d-%d", w, i)},
+						})
+					case 1:
+						_, _ = callTool(srv, "list_repositories", nil)
+					case 2:
+						_, _ = callTool(srv, "scan_workspace", nil)
+					default:
+						_, _ = callTool(srv, "get_repository_context", map[string]any{
+							"repo": "github.com/example/beta",
+						})
+					}
+				}
+			}(w)
+		}
+		wg.Wait()
 	})
 })
 

--- a/internal/mcpserver/resolve.go
+++ b/internal/mcpserver/resolve.go
@@ -22,10 +22,13 @@ func resolveRepo(reg *registry.Registry, repo string) (*registry.Entry, error) {
 		return nil, fmt.Errorf("registry not loaded")
 	}
 
-	// An absolute path identifies exactly one checkout.
+	// An absolute path identifies exactly one checkout. Normalize both sides
+	// with filepath.Clean so equivalent-but-non-canonical forms (e.g. a
+	// trailing slash, or "." / ".." segments) still match the stored path.
 	if filepath.IsAbs(repo) {
+		want := filepath.Clean(repo)
 		for i := range reg.Entries {
-			if reg.Entries[i].Path == repo {
+			if filepath.Clean(reg.Entries[i].Path) == want {
 				return &reg.Entries[i], nil
 			}
 		}

--- a/internal/mcpserver/resolve.go
+++ b/internal/mcpserver/resolve.go
@@ -9,25 +9,43 @@ import (
 )
 
 // resolveRepo resolves a repo identifier (repo_id or absolute path) to a
-// registry entry. It searches by repo_id first, then falls back to path match.
+// registry entry.
+//
+// An absolute path selects a single checkout unambiguously, so it is matched
+// first. A repo_id may resolve to multiple local checkouts; rather than
+// silently acting on an arbitrary one (which would let set_labels/get_* mutate
+// or report on the wrong checkout), an ambiguous repo_id is rejected with a
+// clear error, mirroring engine/actions.go's DeleteRepo behavior. Callers with
+// more than one checkout must disambiguate with the checkout's absolute path.
 func resolveRepo(reg *registry.Registry, repo string) (*registry.Entry, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("registry not loaded")
 	}
 
-	// Try repo_id match first.
-	if entry := reg.FindByRepoID(repo); entry != nil {
-		return entry, nil
-	}
-
-	// Try absolute path match.
+	// An absolute path identifies exactly one checkout.
 	if filepath.IsAbs(repo) {
 		for i := range reg.Entries {
 			if reg.Entries[i].Path == repo {
 				return &reg.Entries[i], nil
 			}
 		}
+		return nil, fmt.Errorf("repository %q not found in registry", repo)
 	}
 
-	return nil, fmt.Errorf("repository %q not found in registry", repo)
+	// Otherwise treat the identifier as a repo_id, which may map to several
+	// checkouts. Collect all matches so ambiguity can be detected.
+	var matches []int
+	for i := range reg.Entries {
+		if reg.Entries[i].RepoID == repo {
+			matches = append(matches, i)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("repository %q not found in registry", repo)
+	case 1:
+		return &reg.Entries[matches[0]], nil
+	default:
+		return nil, fmt.Errorf("repo %q is ambiguous: found %d local checkouts; pass the checkout's absolute path instead", repo, len(matches))
+	}
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -2,7 +2,9 @@
 package mcpserver
 
 import (
+	"context"
 	"sort"
+	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -16,6 +18,16 @@ type MCPServer struct {
 	cfgPath string
 	logger  obs.Logger
 	inner   *server.MCPServer
+
+	// mu serializes every tool and resource handler. ServeStdio dispatches
+	// tool calls on a concurrent worker pool, and handlers read, mutate,
+	// sort, and prune the shared *registry.Registry lock-free. Without this
+	// gate two overlapping calls trigger a fatal concurrent map/slice
+	// read-write that the SDK cannot recover from, killing the server. A
+	// single server-level lock is the conservative fix: registry operations
+	// are cheap relative to the git I/O they gate, so full serialization
+	// costs little and removes the race entirely.
+	mu sync.Mutex
 }
 
 // New creates and configures an MCPServer with all tools and resources registered.
@@ -65,29 +77,54 @@ func ReadOnlyToolNames() []string {
 func (s *MCPServer) registerTools() {
 	s.inner.AddTools(
 		// Phase 1: core read tools
-		server.ServerTool{Tool: listRepositoriesTool(), Handler: s.handleListRepositories},
-		server.ServerTool{Tool: getRepositoryContextTool(), Handler: s.handleGetRepositoryContext},
-		server.ServerTool{Tool: getWorkspaceConfigTool(), Handler: s.handleGetWorkspaceConfig},
+		server.ServerTool{Tool: listRepositoriesTool(), Handler: s.serializeTool(s.handleListRepositories)},
+		server.ServerTool{Tool: getRepositoryContextTool(), Handler: s.serializeTool(s.handleGetRepositoryContext)},
+		server.ServerTool{Tool: getWorkspaceConfigTool(), Handler: s.serializeTool(s.handleGetWorkspaceConfig)},
 		// Phase 2: full read surface
-		server.ServerTool{Tool: buildWorkspaceInventoryTool(), Handler: s.handleBuildWorkspaceInventory},
-		server.ServerTool{Tool: selectRepositoriesTool(), Handler: s.handleSelectRepositories},
-		server.ServerTool{Tool: getRepoMetadataTool(), Handler: s.handleGetRepoMetadata},
-		server.ServerTool{Tool: getAuthoritativePathsTool(), Handler: s.handleGetAuthoritativePaths},
-		server.ServerTool{Tool: getRelatedRepositoriesTool(), Handler: s.handleGetRelatedRepositories},
+		server.ServerTool{Tool: buildWorkspaceInventoryTool(), Handler: s.serializeTool(s.handleBuildWorkspaceInventory)},
+		server.ServerTool{Tool: selectRepositoriesTool(), Handler: s.serializeTool(s.handleSelectRepositories)},
+		server.ServerTool{Tool: getRepoMetadataTool(), Handler: s.serializeTool(s.handleGetRepoMetadata)},
+		server.ServerTool{Tool: getAuthoritativePathsTool(), Handler: s.serializeTool(s.handleGetAuthoritativePaths)},
+		server.ServerTool{Tool: getRelatedRepositoriesTool(), Handler: s.serializeTool(s.handleGetRelatedRepositories)},
 		// Phase 3: mutation tools
-		server.ServerTool{Tool: scanWorkspaceTool(), Handler: s.handleScanWorkspace},
-		server.ServerTool{Tool: planSyncTool(), Handler: s.handlePlanSync},
-		server.ServerTool{Tool: executeSyncTool(), Handler: s.handleExecuteSync},
-		server.ServerTool{Tool: setLabelsTool(), Handler: s.handleSetLabels},
-		server.ServerTool{Tool: addRepositoryTool(), Handler: s.handleAddRepository},
-		server.ServerTool{Tool: removeRepositoryTool(), Handler: s.handleRemoveRepository},
+		server.ServerTool{Tool: scanWorkspaceTool(), Handler: s.serializeTool(s.handleScanWorkspace)},
+		server.ServerTool{Tool: planSyncTool(), Handler: s.serializeTool(s.handlePlanSync)},
+		server.ServerTool{Tool: executeSyncTool(), Handler: s.serializeTool(s.handleExecuteSync)},
+		server.ServerTool{Tool: setLabelsTool(), Handler: s.serializeTool(s.handleSetLabels)},
+		server.ServerTool{Tool: addRepositoryTool(), Handler: s.serializeTool(s.handleAddRepository)},
+		server.ServerTool{Tool: removeRepositoryTool(), Handler: s.serializeTool(s.handleRemoveRepository)},
 	)
 }
 
 func (s *MCPServer) registerResources() {
-	s.inner.AddResource(configResource(), s.handleConfigResource)
-	s.inner.AddResource(registryResource(), s.handleRegistryResource)
-	s.inner.AddResourceTemplate(repoTemplate(), s.handleRepoResource)
+	s.inner.AddResource(configResource(), s.serializeResource(s.handleConfigResource))
+	s.inner.AddResource(registryResource(), s.serializeResource(s.handleRegistryResource))
+	s.inner.AddResourceTemplate(repoTemplate(), s.serializeResource(s.handleRepoResource))
+}
+
+// serializeTool wraps a tool handler so it holds the server-level mutex for
+// the duration of the call, serializing all registry access. See MCPServer.mu.
+func (s *MCPServer) serializeTool(h server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return h(ctx, req)
+	}
+}
+
+// serializeResource wraps a resource handler under the same server-level mutex
+// as tool handlers, so a resource read cannot race a concurrent tool mutation.
+// Unnamed func types are used so the result is assignable to both
+// server.ResourceHandlerFunc (AddResource) and
+// server.ResourceTemplateHandlerFunc (AddResourceTemplate).
+func (s *MCPServer) serializeResource(
+	h func(context.Context, mcp.ReadResourceRequest) ([]mcp.ResourceContents, error),
+) func(context.Context, mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return h(ctx, req)
+	}
 }
 
 // --- Tool definitions ---
@@ -326,6 +363,9 @@ func removeRepositoryTool() mcp.Tool {
 		),
 		mcp.WithBoolean("delete_files",
 			mcp.Description("Also delete files on disk (default: false)"),
+		),
+		mcp.WithBoolean("confirm",
+			mcp.Description("Required (must be true) when delete_files=true. Safety gate for permanent working-tree deletion."),
 		),
 	)
 }

--- a/internal/mcpserver/tools_mutation.go
+++ b/internal/mcpserver/tools_mutation.go
@@ -121,7 +121,10 @@ type syncPlanEntry struct {
 }
 
 func (s *MCPServer) handlePlanSync(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	opts := parseSyncOptions(req)
+	opts, err := parseSyncOptions(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 	opts.DryRun = true // plan_sync is always dry-run
 
 	results, err := s.engine.Sync(ctx, opts)
@@ -165,7 +168,10 @@ func (s *MCPServer) handleExecuteSync(ctx context.Context, req mcp.CallToolReque
 		return mcp.NewToolResultError("safety gate: execute_sync requires confirm=true"), nil
 	}
 
-	opts := parseSyncOptions(req)
+	opts, err := parseSyncOptions(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 	opts.DryRun = false
 	opts.ContinueOnError = true
 
@@ -311,26 +317,70 @@ func (s *MCPServer) handleRemoveRepository(_ context.Context, req mcp.CallToolRe
 	}
 	deleteFiles := req.GetBool("delete_files", false)
 
-	if err := s.engine.DeleteRepo(context.Background(), repoArg, s.cfgPath, deleteFiles); err != nil {
+	// Deleting files permanently removes the working tree via os.RemoveAll.
+	// Gate it behind an explicit strict-bool confirm=true, mirroring the
+	// execute_sync safety gate. Tracking-only removal (the default) is not
+	// destructive on disk and needs no confirmation.
+	if deleteFiles {
+		confirm, err := requireStrictBoolArg(req, "confirm")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if !confirm {
+			return mcp.NewToolResultError("safety gate: remove_repository with delete_files=true requires confirm=true"), nil
+		}
+	}
+
+	// Resolve through resolveRepo so an absolute checkout path works (the
+	// schema advertises "repo_id or absolute path"). DeleteRepo itself only
+	// matches by repo_id, so we hand it the resolved entry's RepoID.
+	entry, err := resolveRepo(s.engine.Registry(), repoArg)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if err := s.engine.DeleteRepo(context.Background(), entry.RepoID, s.cfgPath, deleteFiles); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	return mcp.NewToolResultJSON(removeRepoResponse{
-		RepoID:  repoArg,
+		RepoID:  entry.RepoID,
 		Removed: true,
 	})
 }
 
 // --- shared helpers ---
 
-func parseSyncOptions(req mcp.CallToolRequest) engine.SyncOptions {
+// validSyncFilters is the set of health filters accepted by plan_sync and
+// execute_sync. It mirrors engine.FilterKind's known values. It is kept as a
+// local list (not derived from an engine symbol) so this package validates
+// input independently: an unknown/typo filter must be rejected here rather
+// than fail open in the engine and silently sync ALL repos.
+var validSyncFilters = map[string]struct{}{
+	"all":             {},
+	"errors":          {},
+	"dirty":           {},
+	"clean":           {},
+	"gone":            {},
+	"diverged":        {},
+	"behind":          {},
+	"ahead":           {},
+	"equal":           {},
+	"remote-mismatch": {},
+	"missing":         {},
+}
+
+func parseSyncOptions(req mcp.CallToolRequest) (engine.SyncOptions, error) {
 	filterRaw := strings.ToLower(strings.TrimSpace(req.GetString("filter", "all")))
+	if _, ok := validSyncFilters[filterRaw]; !ok {
+		return engine.SyncOptions{}, fmt.Errorf("invalid filter %q: must be one of all, errors, dirty, clean, gone, diverged, behind, ahead, equal, remote-mismatch, missing", filterRaw)
+	}
 	return engine.SyncOptions{
 		Filter:      engine.FilterKind(filterRaw),
 		UpdateLocal: req.GetBool("update_local", false),
 		PushLocal:   req.GetBool("push_local", false),
 		Force:       req.GetBool("force", false),
-	}
+	}, nil
 }
 
 func optionalStringSliceArg(req mcp.CallToolRequest, name string) ([]string, error) {

--- a/internal/mcpserver/tools_mutation.go
+++ b/internal/mcpserver/tools_mutation.go
@@ -310,7 +310,7 @@ type removeRepoResponse struct {
 	Removed bool   `json:"removed"`
 }
 
-func (s *MCPServer) handleRemoveRepository(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *MCPServer) handleRemoveRepository(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	repoArg, err := req.RequireString("repo")
 	if err != nil {
 		return mcp.NewToolResultError("missing required parameter: repo"), nil
@@ -339,7 +339,7 @@ func (s *MCPServer) handleRemoveRepository(_ context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	if err := s.engine.DeleteRepo(context.Background(), entry.RepoID, s.cfgPath, deleteFiles); err != nil {
+	if err := s.engine.DeleteRepo(ctx, entry.RepoID, s.cfgPath, deleteFiles); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 


### PR DESCRIPTION
## Summary

Resolves eight verified code-review findings in the MCP server (`internal/mcpserver/`) and MCP installer (`internal/mcpinstall/`). All changes are confined to those two packages and add no new exported symbols to other packages, so this PR builds and merges independently off `main`.

## Findings fixed

### `internal/mcpserver/`
- **[P1] Finding 1 — `remove_repository{delete_files:true}` had no confirmation gate** (`tools_mutation.go`). It called `engine.DeleteRepo` → `os.RemoveAll` (permanent working-tree deletion) unconfirmed. Now requires a strict-bool `confirm=true`, mirroring `execute_sync`. Added a `confirm` param to the tool schema. Tracking-only removal (the default, non-destructive on disk) still needs no confirmation.
- **[P1] Finding 2 — sync filter cast without validation** (`tools_mutation.go`). An unknown/typo filter (e.g. `execute_sync{filter:"drity",force:true,push_local:true}`) failed open in the engine and force-pushed ALL repos. `parseSyncOptions` now validates the filter against a **local** allow-list (no dependency on an engine symbol) and returns a tool error for unknown values, in both `plan_sync` and `execute_sync`.
- **[P1] Finding 3 — no locking around the shared registry** (`server.go`). `ServeStdio` runs a concurrent worker pool; handlers read/mutate/sort/prune the shared `*registry.Registry` lock-free, so two overlapping calls faulted with a concurrent map/slice access the SDK cannot recover from. Added a server-level `sync.Mutex` and wrapped every tool **and** resource handler with it (`serializeTool`/`serializeResource`). Conservative full serialization — registry ops are cheap relative to the git I/O they gate.
- **[P2] Finding 4 — `resolveRepo` returned the first entry for an ambiguous `repo_id`** (`resolve.go`). It now errors on ambiguity (mirroring `engine/actions.go`); an absolute path still disambiguates to a single checkout.
- **[P2] Finding 5 — `remove_repository` bypassed `resolveRepo`** (`tools_mutation.go`), so an absolute path didn't work despite the schema advertising "repo_id or absolute path". Now routes through `resolveRepo` and hands `DeleteRepo` the resolved `RepoID`.
- **[DEAD CODE] Finding 8 — `EngineAPI.RepairUpstream/ResetRepo/Adapter()`** (`engine.go`) had no production caller (only mock stubs). Removed from the interface and the test mock. Confirmed unreferenced by repo-wide grep.

### `internal/mcpinstall/`
- **[P1 data loss] Finding 6 — Codex/Grok `config.toml` comments erased on install** (`codex.go`, `grok.go`). The map round-trip through go-toml/v2 drops all comment trivia. **Decision (documented in code):** a lossless in-place edit is not feasible with go-toml/v2 within scope, so we take the **fail-safe** path — detect comments and refuse to rewrite, directing the user to edit manually. `tomlHasComments` skips over basic/literal/multi-line strings (so `#` inside a string value is not a false positive) and biases toward detection (at worst we refuse a safe write; we never silently destroy comments). The guard fires only when a rewrite would actually happen — a no-op remove of an absent entry still succeeds.
- **[P2] Finding 7 — new config files created world-readable `0o644`** (`claude.go`, `codex.go`, `opencode.go`, and also `grok.go`, which has the same issue and an `env` secret field). These can hold MCP env/secrets; new files are now created `0o600` via a shared `newConfigFileMode` constant. Existing-file mode preservation (already correct in `WriteAtomic`) is unchanged.

## Tests added
- Table-driven / ginkgo specs for each behavioral change, matching repo style.
- Finding 1: reject missing/false/non-bool `confirm`; accept `confirm=true`; no confirm for tracking-only.
- Finding 2: `plan_sync`/`execute_sync` reject an unknown filter.
- Finding 4: `set_labels`/`get_repository_context` on an ambiguous `repo_id` error; absolute path disambiguates.
- Finding 5: `remove_repository` by absolute path works; unknown repo errors before touching the engine.
- Finding 3: a concurrent-access spec drives 8 goroutines × overlapping tool calls; **verified it faults under `-race` before the serialization fix and passes after**.
- Finding 6: `tomlHasComments` unit table; codex+grok refuse a commented file (file left untouched); uncommented file still written; no-op remove on a commented file succeeds.
- Finding 7: new-file `0o600` assertion across all four adapters.

## Verification (Go 1.26.5, based on current `origin/main`)
- `go build ./...` — pass
- `go vet ./internal/mcpserver/... ./internal/mcpinstall/...` — pass
- `staticcheck@v0.7.0 ./internal/mcpserver/... ./internal/mcpinstall/...` — pass
- `go test ./internal/mcpserver/... ./internal/mcpinstall/...` — pass
- `go test -race ./internal/mcpserver/... ./internal/mcpinstall/...` — pass

## Notes for the reviewer
- **Finding 5 residual (in-scope limit):** `engine.DeleteRepo` matches by `repo_id` only and re-checks ambiguity internally; it lives outside this PR's file scope. So removing by absolute path works for single-checkout repos, but a path pointing at one of several checkouts sharing a `repo_id` is still rejected by `DeleteRepo` (safe: it errors rather than deleting the wrong tree). Fully path-aware deletion would require an engine-side change and is deliberately out of scope.
- **Finding 6 alternative considered:** a comment-preserving TOML editor (e.g. tracking the raw AST) was rejected as out-of-scope for this fix; the fail-safe refusal is the conservative choice and is reversible if a lossless editor is added later.
- Pre-existing, unrelated: `internal/engine` test files fail to build on this base (`ExecuteSyncPlan`/`SyncOutcome` undefined) — untouched by this PR and out of scope.
