### PR TITLE
fix(cli): resolve verified mutation bugs in add/move/edit/import/sync/repair-upstream/export

### DIFF
--- a/cmd/repokeeper/add.go
+++ b/cmd/repokeeper/add.go
@@ -67,11 +67,7 @@ var addCmd = &cobra.Command{
 
 		target := args[0]
 		rawURL := args[1]
-		targetAbs, err := filepath.Abs(filepath.Join(cwd, target))
-		if err != nil {
-			return err
-		}
-		targetAbs = filepath.Clean(targetAbs)
+		targetAbs := resolveAbsoluteTargetPath(cwd, target)
 
 		if _, err := os.Stat(targetAbs); err == nil {
 			return fmt.Errorf("target path already exists: %q", targetAbs)
@@ -147,6 +143,21 @@ var addCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// resolveAbsoluteTargetPath returns a cleaned absolute path for target. An
+// already-absolute target is used as-is (only cleaned); a relative target is
+// joined against cwd. This mirrors the absolute-first pattern used by
+// canonicalPathForMatch in describe.go. Unconditionally joining with
+// filepath.Join(cwd, target) is wrong for an absolute target: Join does not
+// special-case absolute path segments, so it re-roots the target under cwd
+// instead of preserving it (e.g. Join("/cwd", "/abs/target") yields
+// "/cwd/abs/target"), silently placing operations at the wrong path.
+func resolveAbsoluteTargetPath(cwd, target string) string {
+	if filepath.IsAbs(target) {
+		return filepath.Clean(target)
+	}
+	return filepath.Clean(filepath.Join(cwd, target))
 }
 
 func init() {

--- a/cmd/repokeeper/add_test.go
+++ b/cmd/repokeeper/add_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+package repokeeper
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAbsoluteTargetPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		cwd    string
+		target string
+		want   string
+	}{
+		{name: "relative target joins cwd", cwd: "/work/root", target: "repos/repo-a", want: filepath.FromSlash("/work/root/repos/repo-a")},
+		{name: "relative target with dot segments is cleaned", cwd: "/work/root", target: "./repos/../repos/repo-a", want: filepath.FromSlash("/work/root/repos/repo-a")},
+		{
+			// Regression test: an absolute target must be used as-is, not
+			// re-rooted under cwd. filepath.Join("/work/root", "/abs/target")
+			// would previously yield "/work/root/abs/target" instead of
+			// "/abs/target".
+			name:   "absolute target is preserved, not re-rooted under cwd",
+			cwd:    "/work/root",
+			target: "/abs/target",
+			want:   filepath.FromSlash("/abs/target"),
+		},
+		{name: "absolute target is cleaned", cwd: "/work/root", target: "/abs//target/../target", want: filepath.FromSlash("/abs/target")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveAbsoluteTargetPath(tc.cwd, tc.target); got != tc.want {
+				t.Fatalf("resolveAbsoluteTargetPath(%q, %q) = %q, want %q", tc.cwd, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddCommandWithAbsoluteTargetDoesNotReRootUnderCWD(t *testing.T) {
+	cfgPath := writeEmptyConfig(t)
+	cleanup := withConfigAndCWD(t, cfgPath)
+	defer cleanup()
+
+	src := filepath.Join(t.TempDir(), "source")
+	mustRunGit(t, filepath.Dir(src), "init", src)
+	mustRunGit(t, src, "commit", "--allow-empty", "-m", "init")
+
+	// The target is an absolute path that lives entirely outside cwd
+	// (filepath.Dir(cfgPath), per withConfigAndCWD). Before the fix,
+	// filepath.Join(cwd, target) re-rooted this under cwd instead of
+	// cloning to the path the caller asked for.
+	absTarget := filepath.Join(t.TempDir(), "elsewhere", "repo-a")
+
+	addCmd.SetOut(&bytes.Buffer{})
+	addCmd.SetContext(context.Background())
+	defer addCmd.SetOut(os.Stdout)
+	_ = addCmd.Flags().Set("registry", "")
+	_ = addCmd.Flags().Set("branch", "")
+	_ = addCmd.Flags().Set("mirror", "false")
+	if err := addCmd.RunE(addCmd, []string{absTarget, src}); err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	if _, err := os.Stat(absTarget); err != nil {
+		t.Fatalf("expected repo cloned at absolute target %q: %v", absTarget, err)
+	}
+	wrongTarget := filepath.Join(filepath.Dir(cfgPath), absTarget)
+	if _, err := os.Stat(wrongTarget); !os.IsNotExist(err) {
+		t.Fatalf("expected no repo re-rooted under cwd at %q, stat err=%v", wrongTarget, err)
+	}
+}

--- a/cmd/repokeeper/command_parsing_test.go
+++ b/cmd/repokeeper/command_parsing_test.go
@@ -68,6 +68,19 @@ func TestSyncResultNeedsConfirmationTable(t *testing.T) {
 			res:  engine.SyncResult{Action: "git clone --branch main --single-branch git@github.com:org/repo.git /tmp/repo"},
 			want: true,
 		},
+		{
+			// Regression: --update-local --push-local pushes to a remote,
+			// which is exactly the kind of local/remote-mutating operation
+			// this gate exists to confirm before executing.
+			name: "git push alone",
+			res:  engine.SyncResult{Action: "git push"},
+			want: true,
+		},
+		{
+			name: "fetch + push",
+			res:  engine.SyncResult{Action: "git fetch --all --prune --prune-tags --no-recurse-submodules && git push"},
+			want: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/repokeeper/command_run_test.go
+++ b/cmd/repokeeper/command_run_test.go
@@ -561,6 +561,144 @@ func TestSyncRunEUnsupportedFormat(t *testing.T) {
 	}
 }
 
+func TestSyncRunEDryRunSkipsConfirmationPrompt(t *testing.T) {
+	// Regression test: --dry-run never applies any planned operation, so it
+	// must never block on the interactive confirmation prompt. Before the
+	// fix, a plan requiring confirmation (here, a planned --checkout-missing
+	// clone) still triggered the prompt even under --dry-run; with no stdin
+	// available the prompt reads EOF, is treated as "declined", and RunE
+	// returned early without ever printing the requested -o json plan.
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".repokeeper.yaml")
+	cfg := config.DefaultConfig()
+	cfg.Registry = &registry.Registry{
+		Entries: []registry.Entry{
+			{
+				RepoID:    "github.com/org/repo-missing",
+				Path:      filepath.Join(tmp, "missing-repo"),
+				RemoteURL: "https://example.invalid/org/repo-missing.git",
+				Branch:    "main",
+				Status:    registry.StatusMissing,
+				LastSeen:  time.Now(),
+			},
+		},
+	}
+	if err := config.Save(&cfg, cfgPath); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	cleanup := withTestConfig(t, cfgPath)
+	defer cleanup()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	syncCmd.SetOut(out)
+	syncCmd.SetErr(errOut)
+	// Deliberately empty stdin: a prompt read here hits EOF immediately.
+	syncCmd.SetIn(bytes.NewReader(nil))
+	defer syncCmd.SetOut(os.Stdout)
+	defer syncCmd.SetErr(os.Stderr)
+	defer syncCmd.SetIn(nil)
+
+	_ = syncCmd.Flags().Set("only", "all")
+	_ = syncCmd.Flags().Set("dry-run", "true")
+	_ = syncCmd.Flags().Set("yes", "false")
+	_ = syncCmd.Flags().Set("checkout-missing", "true")
+	_ = syncCmd.Flags().Set("format", "json")
+	defer func() {
+		_ = syncCmd.Flags().Set("checkout-missing", "false")
+		_ = syncCmd.Flags().Set("dry-run", "false")
+	}()
+
+	if err := syncCmd.RunE(syncCmd, nil); err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+
+	if strings.Contains(errOut.String(), "sync cancelled") {
+		t.Fatalf("expected --dry-run to skip the confirmation prompt entirely, got a cancellation: %q", errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "\"repo_id\": \"github.com/org/repo-missing\"") {
+		t.Fatalf("expected dry-run plan output despite empty stdin, got: %q", got)
+	}
+}
+
+func TestSyncRunEPersistsRegistryAfterCheckoutMissingClone(t *testing.T) {
+	// Regression test: a successful --checkout-missing clone must be
+	// persisted to the config/registry file. Before the fix, the engine only
+	// updated its in-memory registry (the same *registry.Registry as
+	// cfg.Registry), and sync's RunE never called config.Save, so the next
+	// sync re-planned and re-attempted the same clone indefinitely.
+	tmp := t.TempDir()
+	remote := filepath.Join(tmp, "remote.git")
+	mustRunGit(t, tmp, "init", "--bare", remote)
+
+	seed := filepath.Join(tmp, "seed")
+	mustRunGit(t, tmp, "clone", remote, seed)
+	mustRunGit(t, seed, "checkout", "-b", "main")
+	mustRunGit(t, seed, "commit", "--allow-empty", "-m", "init")
+	mustRunGit(t, seed, "push", "-u", "origin", "main")
+
+	missingPath := filepath.Join(tmp, "missing-repo")
+	cfgPath := filepath.Join(tmp, ".repokeeper.yaml")
+	cfg := config.DefaultConfig()
+	cfg.Registry = &registry.Registry{
+		Entries: []registry.Entry{
+			{
+				RepoID:    "github.com/org/repo-checkout",
+				Path:      missingPath,
+				RemoteURL: remote,
+				Branch:    "main",
+				Status:    registry.StatusMissing,
+				LastSeen:  time.Now(),
+			},
+		},
+	}
+	if err := config.Save(&cfg, cfgPath); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	cleanup := withTestConfig(t, cfgPath)
+	defer cleanup()
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	syncCmd.SetOut(out)
+	syncCmd.SetErr(errOut)
+	syncCmd.SetContext(context.Background())
+	defer syncCmd.SetOut(os.Stdout)
+	defer syncCmd.SetErr(os.Stderr)
+
+	prevYes, _ := rootCmd.PersistentFlags().GetBool("yes")
+	_ = rootCmd.PersistentFlags().Set("yes", "true")
+	defer func() { _ = rootCmd.PersistentFlags().Set("yes", boolToFlag(prevYes)) }()
+
+	_ = syncCmd.Flags().Set("only", "all")
+	_ = syncCmd.Flags().Set("dry-run", "false")
+	_ = syncCmd.Flags().Set("checkout-missing", "true")
+	_ = syncCmd.Flags().Set("format", "json")
+	defer func() {
+		_ = syncCmd.Flags().Set("checkout-missing", "false")
+	}()
+
+	if err := syncCmd.RunE(syncCmd, nil); err != nil {
+		t.Fatalf("sync run failed: %v", err)
+	}
+	if _, err := os.Stat(missingPath); err != nil {
+		t.Fatalf("expected repo cloned at %q: %v", missingPath, err)
+	}
+
+	reloaded, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	entry := reloaded.Registry.FindByRepoID("github.com/org/repo-checkout")
+	if entry == nil {
+		t.Fatal("expected registry entry to survive reload")
+	}
+	if entry.Status != registry.StatusPresent {
+		t.Fatalf("expected persisted status %q, got %q (checkout-missing clone was not saved to disk)", registry.StatusPresent, entry.Status)
+	}
+}
+
 func TestDescribeRunEPaths(t *testing.T) {
 	cfgPath, regPath := writeTestConfigAndRegistry(t)
 	cleanup := withTestConfig(t, cfgPath)

--- a/cmd/repokeeper/command_run_test.go
+++ b/cmd/repokeeper/command_run_test.go
@@ -599,12 +599,20 @@ func TestSyncRunEDryRunSkipsConfirmationPrompt(t *testing.T) {
 	defer syncCmd.SetErr(os.Stderr)
 	defer syncCmd.SetIn(nil)
 
+	// yes is a root persistent flag, not a local flag on syncCmd, so it must be
+	// set (and restored) on rootCmd.PersistentFlags(); setting it on
+	// syncCmd.Flags() silently fails and leaves the test at the mercy of a
+	// persistent --yes leaked by an earlier test. Force it off here so the
+	// confirmation path is active and this test genuinely proves --dry-run
+	// skips it.
+	prevYes, _ := rootCmd.PersistentFlags().GetBool("yes")
+	_ = rootCmd.PersistentFlags().Set("yes", "false")
 	_ = syncCmd.Flags().Set("only", "all")
 	_ = syncCmd.Flags().Set("dry-run", "true")
-	_ = syncCmd.Flags().Set("yes", "false")
 	_ = syncCmd.Flags().Set("checkout-missing", "true")
 	_ = syncCmd.Flags().Set("format", "json")
 	defer func() {
+		_ = rootCmd.PersistentFlags().Set("yes", boolToFlag(prevYes))
 		_ = syncCmd.Flags().Set("checkout-missing", "false")
 		_ = syncCmd.Flags().Set("dry-run", "false")
 	}()

--- a/cmd/repokeeper/edit.go
+++ b/cmd/repokeeper/edit.go
@@ -187,12 +187,25 @@ func validateEditedRegistryEntry(entry registry.Entry, reg *registry.Registry, i
 		}
 	}
 	if reg != nil {
+		// Multiple registry entries may legitimately share a repo_id (the
+		// supported multi-checkout case: several checkouts of the same
+		// repository at different paths/checkout_ids). Uniqueness is keyed
+		// on (repo_id, checkout_id) when a checkout_id is set, or on
+		// (repo_id, path) otherwise — not on repo_id alone.
+		checkoutID := strings.TrimSpace(entry.CheckoutID)
 		for i := range reg.Entries {
 			if i == index {
 				continue
 			}
-			if reg.Entries[i].RepoID == entry.RepoID {
-				return fmt.Errorf("invalid entry: repo_id %q already exists", entry.RepoID)
+			other := reg.Entries[i]
+			if other.RepoID != entry.RepoID {
+				continue
+			}
+			if checkoutID != "" && strings.TrimSpace(other.CheckoutID) == checkoutID {
+				return fmt.Errorf("invalid entry: repo_id %q and checkout_id %q already exists", entry.RepoID, checkoutID)
+			}
+			if strings.TrimSpace(other.Path) == entryPath {
+				return fmt.Errorf("invalid entry: repo_id %q and path %q already exists", entry.RepoID, entryPath)
 			}
 		}
 	}
@@ -204,8 +217,15 @@ func trackingBranchFromUpstream(upstream string) string {
 	if trimmed == "" {
 		return ""
 	}
-	parts := strings.Split(trimmed, "/")
-	return parts[len(parts)-1]
+	// upstream is "remote/branch"; branch names may themselves contain "/"
+	// (e.g. "origin/feature/x"), so only the first segment (the remote name)
+	// is stripped. Splitting on "/" and taking the last segment would
+	// truncate multi-segment branch names down to their final component.
+	_, branch, found := strings.Cut(trimmed, "/")
+	if !found {
+		return trimmed
+	}
+	return branch
 }
 
 func init() {

--- a/cmd/repokeeper/edit_test.go
+++ b/cmd/repokeeper/edit_test.go
@@ -56,14 +56,116 @@ func writeEditorFixtureScript(t *testing.T, dir, repoPath string, invalidYAML bo
 }
 
 func TestTrackingBranchFromUpstream(t *testing.T) {
-	if got := trackingBranchFromUpstream("origin/main"); got != "main" {
-		t.Fatalf("expected main, got %q", got)
+	tests := []struct {
+		name     string
+		upstream string
+		want     string
+	}{
+		{name: "simple branch", upstream: "origin/main", want: "main"},
+		{
+			// Regression test: branch names may themselves contain "/". Only
+			// the remote (first path segment) must be stripped, not the last
+			// segment — "upstream/release/v1" is remote "upstream" tracking
+			// branch "release/v1", not branch "v1".
+			name:     "branch name containing slashes",
+			upstream: "upstream/release/v1",
+			want:     "release/v1",
+		},
+		{name: "deeply nested branch name", upstream: "origin/feature/team/x", want: "feature/team/x"},
+		{name: "no remote prefix", upstream: "main", want: "main"},
+		{name: "empty upstream", upstream: "", want: ""},
+		{name: "whitespace-only upstream", upstream: "   ", want: ""},
 	}
-	if got := trackingBranchFromUpstream("upstream/release/v1"); got != "v1" {
-		t.Fatalf("expected v1, got %q", got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trackingBranchFromUpstream(tc.upstream); got != tc.want {
+				t.Fatalf("trackingBranchFromUpstream(%q) = %q, want %q", tc.upstream, got, tc.want)
+			}
+		})
 	}
-	if got := trackingBranchFromUpstream(""); got != "" {
-		t.Fatalf("expected empty for empty upstream, got %q", got)
+}
+
+func TestValidateEditedRegistryEntryUniqueness(t *testing.T) {
+	base := func() registry.Entry {
+		return registry.Entry{
+			RepoID: "github.com/org/repo",
+			Path:   "/repos/repo-a",
+			Status: registry.StatusPresent,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		edited  registry.Entry
+		reg     *registry.Registry
+		index   int
+		wantErr bool
+	}{
+		{
+			name:   "no other entries",
+			edited: base(),
+			reg:    &registry.Registry{Entries: []registry.Entry{base()}},
+			index:  0,
+		},
+		{
+			name:   "same repo_id different checkout_id is allowed (multi-checkout)",
+			edited: registry.Entry{RepoID: "github.com/org/repo", CheckoutID: "b", Path: "/repos/repo-b", Status: registry.StatusPresent},
+			reg: &registry.Registry{Entries: []registry.Entry{
+				{RepoID: "github.com/org/repo", CheckoutID: "a", Path: "/repos/repo-a", Status: registry.StatusPresent},
+				{RepoID: "github.com/org/repo", CheckoutID: "b", Path: "/repos/repo-b", Status: registry.StatusPresent},
+			}},
+			index: 1,
+		},
+		{
+			name:   "same repo_id different path, no checkout_id, is allowed (multi-checkout)",
+			edited: registry.Entry{RepoID: "github.com/org/repo", Path: "/repos/repo-b", Status: registry.StatusPresent},
+			reg: &registry.Registry{Entries: []registry.Entry{
+				{RepoID: "github.com/org/repo", Path: "/repos/repo-a", Status: registry.StatusPresent},
+				{RepoID: "github.com/org/repo", Path: "/repos/repo-b", Status: registry.StatusPresent},
+			}},
+			index: 1,
+		},
+		{
+			name:   "same repo_id and same checkout_id is rejected",
+			edited: registry.Entry{RepoID: "github.com/org/repo", CheckoutID: "a", Path: "/repos/repo-b", Status: registry.StatusPresent},
+			reg: &registry.Registry{Entries: []registry.Entry{
+				{RepoID: "github.com/org/repo", CheckoutID: "a", Path: "/repos/repo-a", Status: registry.StatusPresent},
+				{RepoID: "github.com/org/repo", CheckoutID: "a", Path: "/repos/repo-b", Status: registry.StatusPresent},
+			}},
+			index:   1,
+			wantErr: true,
+		},
+		{
+			name:   "same repo_id and same path (no checkout_id) is rejected",
+			edited: registry.Entry{RepoID: "github.com/org/repo", Path: "/repos/repo-a", Status: registry.StatusPresent},
+			reg: &registry.Registry{Entries: []registry.Entry{
+				{RepoID: "github.com/org/repo", Path: "/repos/repo-a", Status: registry.StatusPresent},
+				{RepoID: "github.com/org/repo", Path: "/repos/repo-a", Status: registry.StatusPresent},
+			}},
+			index:   1,
+			wantErr: true,
+		},
+		{
+			name:   "different repo_id never conflicts",
+			edited: registry.Entry{RepoID: "github.com/org/other", Path: "/repos/repo-a", Status: registry.StatusPresent},
+			reg: &registry.Registry{Entries: []registry.Entry{
+				{RepoID: "github.com/org/repo", Path: "/repos/repo-a", Status: registry.StatusPresent},
+				{RepoID: "github.com/org/other", Path: "/repos/repo-a", Status: registry.StatusPresent},
+			}},
+			index: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEditedRegistryEntry(tc.edited, tc.reg, tc.index)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/repokeeper/export.go
+++ b/cmd/repokeeper/export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/skaphos/repokeeper/internal/config"
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/registry"
+	"github.com/skaphos/repokeeper/internal/urlutil"
 	"github.com/skaphos/repokeeper/internal/vcs"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v3"
@@ -68,6 +69,13 @@ var exportCmd = &cobra.Command{
 			exportedRegistry = prepareRegistryForExport(exportedRegistry, bundle.Root)
 			adapter := vcs.NewGitAdapter(nil)
 			populateExportBranches(cmd.Context(), exportedRegistry, adapter.Head, adapter.TrackingStatus)
+			// remote_url must stay usable for import/reconcile, so credentials
+			// embedded in it (https://user:token@host/...) are exported verbatim
+			// rather than silently redacted; warn instead so the operator knows
+			// the bundle carries live credentials in cleartext.
+			if repoIDs := exportEntriesWithEmbeddedCredentials(exportedRegistry); len(repoIDs) > 0 {
+				infof(cmd, "warning: exported bundle embeds credentials in remote_url for %d repo(s): %s (bundle file permissions are restricted to owner-only, but credentials are stored in cleartext)", len(repoIDs), strings.Join(repoIDs, ", "))
+			}
 		}
 		// Export bundles carry registry at the top level only.
 		// config.registry is always omitted to avoid duplicated payloads.
@@ -88,7 +96,9 @@ var exportCmd = &cobra.Command{
 		if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		// Bundle files can carry remote_url credentials (see the warning above),
+		// so write owner-only rather than the previous world-readable 0o644.
+		if err := os.WriteFile(outputPath, data, 0o600); err != nil {
 			return err
 		}
 		infof(cmd, "exported bundle to %s", outputPath)
@@ -101,6 +111,27 @@ func init() {
 	exportCmd.Flags().Bool("include-registry", true, "include registry in the export bundle")
 
 	rootCmd.AddCommand(exportCmd)
+}
+
+// exportEntriesWithEmbeddedCredentials returns the repo IDs of entries whose
+// remote_url carries embedded credentials (e.g. https://user:token@host/...).
+// It reuses urlutil.RedactCredentials as the detector: a URL that redaction
+// changes is a URL that had credentials embedded in it.
+func exportEntriesWithEmbeddedCredentials(reg *registry.Registry) []string {
+	if reg == nil {
+		return nil
+	}
+	var repoIDs []string
+	for _, entry := range reg.Entries {
+		url := strings.TrimSpace(entry.RemoteURL)
+		if url == "" {
+			continue
+		}
+		if urlutil.RedactCredentials(url) != url {
+			repoIDs = append(repoIDs, entry.RepoID)
+		}
+	}
+	return repoIDs
 }
 
 func prepareRegistryForExport(reg *registry.Registry, root string) *registry.Registry {

--- a/cmd/repokeeper/export.go
+++ b/cmd/repokeeper/export.go
@@ -98,6 +98,12 @@ var exportCmd = &cobra.Command{
 		}
 		// Bundle files can carry remote_url credentials (see the warning above),
 		// so write owner-only rather than the previous world-readable 0o644.
+		// os.WriteFile only applies the perm bits when it creates the file, so an
+		// existing (possibly 0o644) bundle would keep its old mode. Remove any
+		// existing file first to guarantee a fresh 0o600 create.
+		if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
 		if err := os.WriteFile(outputPath, data, 0o600); err != nil {
 			return err
 		}

--- a/cmd/repokeeper/export_test.go
+++ b/cmd/repokeeper/export_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -361,5 +362,99 @@ func TestExportCommandRunEWritesFile(t *testing.T) {
 	}
 	if _, err := os.Stat(outputFile); err != nil {
 		t.Fatalf("expected export file at %s: %v", outputFile, err)
+	}
+}
+
+func TestExportCommandRunEWritesFileOwnerOnlyPermissions(t *testing.T) {
+	// Regression test: exported bundles can carry remote_url credentials
+	// (see TestExportCommandRunEWarnsOnEmbeddedCredentials), so the bundle
+	// file must not be world/group-readable.
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file mode bits are not meaningful on windows")
+	}
+	cfgPath := writeEmptyConfig(t)
+	cleanup := withConfigAndCWD(t, cfgPath)
+	defer cleanup()
+
+	outputFile := filepath.Join(t.TempDir(), "bundle.yaml")
+	exportCmd.SetContext(context.Background())
+	_ = exportCmd.Flags().Set("include-registry", "false")
+	_ = exportCmd.Flags().Set("output", "-")
+
+	if err := exportCmd.RunE(exportCmd, []string{outputFile}); err != nil {
+		t.Fatalf("export run failed: %v", err)
+	}
+	info, err := os.Stat(outputFile)
+	if err != nil {
+		t.Fatalf("stat export file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected owner-only file mode 0600, got %#o", got)
+	}
+}
+
+func TestExportCommandRunEWarnsOnEmbeddedCredentials(t *testing.T) {
+	cfgPath := writeEmptyConfig(t)
+	cleanup := withConfigAndCWD(t, cfgPath)
+	defer cleanup()
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Registry = &registry.Registry{
+		Entries: []registry.Entry{
+			{
+				RepoID:    "github.com/org/repo-creds",
+				Path:      filepath.Join(t.TempDir(), "repo-creds"),
+				RemoteURL: "https://user:token@github.com/org/repo-creds.git",
+				Status:    registry.StatusPresent,
+			},
+		},
+	}
+	if err := config.Save(cfg, cfgPath); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	errOut := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	exportCmd.SetOut(out)
+	exportCmd.SetErr(errOut)
+	exportCmd.SetContext(context.Background())
+	defer exportCmd.SetOut(os.Stdout)
+	defer exportCmd.SetErr(os.Stderr)
+
+	_ = exportCmd.Flags().Set("include-registry", "true")
+	_ = exportCmd.Flags().Set("output", "-")
+
+	if err := exportCmd.RunE(exportCmd, nil); err != nil {
+		t.Fatalf("export run failed: %v", err)
+	}
+
+	if !strings.Contains(errOut.String(), "embeds credentials") || !strings.Contains(errOut.String(), "github.com/org/repo-creds") {
+		t.Fatalf("expected embedded-credentials warning naming the repo, got: %q", errOut.String())
+	}
+	// remote_url must stay usable for import/reconcile, so it is not redacted
+	// in the bundle itself.
+	if !strings.Contains(out.String(), "user:token@github.com") {
+		t.Fatalf("expected remote_url to remain usable (not redacted) in bundle output, got: %q", out.String())
+	}
+}
+
+func TestExportEntriesWithEmbeddedCredentials(t *testing.T) {
+	reg := &registry.Registry{
+		Entries: []registry.Entry{
+			{RepoID: "a", RemoteURL: "https://user:token@github.com/org/a.git"},
+			{RepoID: "b", RemoteURL: "https://github.com/org/b.git"},
+			{RepoID: "c", RemoteURL: "git@github.com:org/c.git"},
+			{RepoID: "d", RemoteURL: ""},
+		},
+	}
+	got := exportEntriesWithEmbeddedCredentials(reg)
+	if len(got) != 1 || got[0] != "a" {
+		t.Fatalf("expected only repo %q flagged, got %#v", "a", got)
+	}
+	if got := exportEntriesWithEmbeddedCredentials(nil); got != nil {
+		t.Fatalf("expected nil result for nil registry, got %#v", got)
 	}
 }

--- a/cmd/repokeeper/import.go
+++ b/cmd/repokeeper/import.go
@@ -61,6 +61,17 @@ var importCmd = &cobra.Command{
 			includeRegistry = false
 			preserveRegistryPath = false
 		}
+		// In merge mode, cloning bundle repos while --include-registry=false
+		// would still register them into the local registry: ExecuteImportClones
+		// upserts every cloned entry into cfg.Registry regardless of
+		// includeRegistry, so skipping only the merge step let cloned repos leak
+		// back in. Replace mode already clears cfg.Registry when
+		// includeRegistry is false (see mergeImportedRegistry), which naturally
+		// short-circuits planImportedEntries; merge mode needs this explicit
+		// gate since the existing local registry is left in place.
+		if mode == importModeMerge && !includeRegistry {
+			cloneRepos = false
+		}
 
 		inputPath := "-"
 		if len(args) == 1 {

--- a/cmd/repokeeper/import_test.go
+++ b/cmd/repokeeper/import_test.go
@@ -680,6 +680,81 @@ func TestImportCommandRunEMergePreflightTreatsNewBundleRepoAsCloneCandidate(t *t
 	}
 }
 
+func TestImportCommandRunEMergeIncludeRegistryFalseDoesNotCloneOrRegisterBundleRepos(t *testing.T) {
+	// Regression test: in merge mode, --include-registry=false must suppress
+	// cloning too. Previously only --file-only disabled cloning, so a bundled
+	// repo would still be cloned and (via ExecuteImportClones, which upserts
+	// every cloned entry into cfg.Registry) registered locally even though
+	// the caller explicitly asked to exclude the registry.
+	cfgPath := writeEmptyConfig(t)
+	cleanup := withConfigAndCWD(t, cfgPath)
+	defer cleanup()
+
+	bundle := exportBundle{
+		Version: 1,
+		Root:    "/source/root",
+		Config:  config.DefaultConfig(),
+		Registry: &registry.Registry{
+			Entries: []registry.Entry{
+				{
+					RepoID:    "github.com/org/repo-a",
+					Path:      "/source/root/team/repo-a",
+					RemoteURL: "https://example.invalid/org/repo-a.git",
+					Branch:    "main",
+					Status:    registry.StatusPresent,
+				},
+			},
+		},
+	}
+	bundlePath := filepath.Join(t.TempDir(), "bundle.yaml")
+	data, err := yaml.Marshal(&bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	if err := os.WriteFile(bundlePath, data, 0o644); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	errOut := &bytes.Buffer{}
+	importCmd.SetErr(errOut)
+	defer importCmd.SetErr(os.Stderr)
+	importCmd.SetOut(&bytes.Buffer{})
+	defer importCmd.SetOut(os.Stdout)
+	importCmd.SetContext(context.Background())
+
+	prevYes, _ := rootCmd.PersistentFlags().GetBool("yes")
+	_ = rootCmd.PersistentFlags().Set("yes", "true")
+	defer func() { _ = rootCmd.PersistentFlags().Set("yes", boolToFlag(prevYes)) }()
+
+	_ = importCmd.Flags().Set("mode", "merge")
+	_ = importCmd.Flags().Set("on-conflict", "bundle")
+	_ = importCmd.Flags().Set("file-only", "false")
+	_ = importCmd.Flags().Set("include-registry", "false")
+
+	if err := importCmd.RunE(importCmd, []string{bundlePath}); err != nil {
+		t.Fatalf("import run failed: %v", err)
+	}
+
+	if strings.Contains(errOut.String(), "Planned import clone operations:") {
+		t.Fatalf("expected no clone planning output with --include-registry=false, got: %q", errOut.String())
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if cfg.Registry != nil {
+		if got := cfg.Registry.FindByRepoID("github.com/org/repo-a"); got != nil {
+			t.Fatalf("expected bundle repo not registered with --include-registry=false, got %+v", got)
+		}
+	}
+
+	targetPath := filepath.Join(filepath.Dir(cfgPath), "team", "repo-a")
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no clone attempted at %q, stat err=%v", targetPath, err)
+	}
+}
+
 func TestImportCommandDefaultsToLocalConfigPath(t *testing.T) {
 	tmp := t.TempDir()
 	origWD, err := os.Getwd()

--- a/cmd/repokeeper/move.go
+++ b/cmd/repokeeper/move.go
@@ -54,11 +54,7 @@ var moveCmd = &cobra.Command{
 			return fmt.Errorf("entry not found for selector %q", args[0])
 		}
 
-		targetAbs, err := filepath.Abs(filepath.Join(cwd, args[1]))
-		if err != nil {
-			return err
-		}
-		targetAbs = filepath.Clean(targetAbs)
+		targetAbs := resolveAbsoluteTargetPath(cwd, args[1])
 		if targetAbs == filepath.Clean(entry.Path) {
 			return fmt.Errorf("target path is unchanged: %q", targetAbs)
 		}

--- a/cmd/repokeeper/move_test.go
+++ b/cmd/repokeeper/move_test.go
@@ -76,6 +76,60 @@ func TestMoveCommandMovesDirectoryAndUpdatesRegistry(t *testing.T) {
 	}
 }
 
+func TestMoveCommandWithAbsoluteTargetDoesNotReRootUnderCWD(t *testing.T) {
+	cfgPath := writeEmptyConfig(t)
+	cleanup := withConfigAndCWD(t, cfgPath)
+	defer cleanup()
+
+	source := filepath.Join(t.TempDir(), "repo-move-abs-source")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Registry = &registry.Registry{
+		Entries: []registry.Entry{{
+			RepoID: "local:repo-move-abs",
+			Path:   source,
+			Status: registry.StatusPresent,
+		}},
+	}
+	if err := config.Save(cfg, cfgPath); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	// The target is an absolute path outside cwd (filepath.Dir(cfgPath), per
+	// withConfigAndCWD). Before the fix, filepath.Join(cwd, target) re-rooted
+	// this under cwd instead of moving to the path the caller asked for.
+	absTarget := filepath.Join(t.TempDir(), "elsewhere", "repo-move-abs-target")
+
+	moveCmd.SetContext(context.Background())
+	_ = moveCmd.Flags().Set("registry", "")
+	if err := moveCmd.RunE(moveCmd, []string{"local:repo-move-abs", absTarget}); err != nil {
+		t.Fatalf("move command failed: %v", err)
+	}
+
+	if _, err := os.Stat(absTarget); err != nil {
+		t.Fatalf("expected repo moved to absolute target %q: %v", absTarget, err)
+	}
+	wrongTarget := filepath.Join(filepath.Dir(cfgPath), absTarget)
+	if _, err := os.Stat(wrongTarget); !os.IsNotExist(err) {
+		t.Fatalf("expected no repo re-rooted under cwd at %q, stat err=%v", wrongTarget, err)
+	}
+
+	cfg, err = config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	got := cfg.Registry.FindByRepoID("local:repo-move-abs")
+	if got == nil || filepath.Clean(got.Path) != filepath.Clean(absTarget) {
+		t.Fatalf("expected registry path %q, got %+v", absTarget, got)
+	}
+}
+
 func TestMoveCommandFailureKeepsRegistryUnchanged(t *testing.T) {
 	cfgPath := writeEmptyConfig(t)
 	cleanup := withConfigAndCWD(t, cfgPath)

--- a/cmd/repokeeper/repair_upstream.go
+++ b/cmd/repokeeper/repair_upstream.go
@@ -51,7 +51,11 @@ var repairUpstreamCmd = &cobra.Command{
 		registryOverride, _ := cmd.Flags().GetString("registry")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		yes := assumeYes(cmd)
-		only, _ := cmd.Flags().GetString("only")
+		onlyRaw, _ := cmd.Flags().GetString("only")
+		only, err := parseUpstreamRepairFilter(onlyRaw)
+		if err != nil {
+			return err
+		}
 		format, _ := cmd.Flags().GetString("format")
 		mode, err := parseOutputMode(format)
 		if err != nil {
@@ -266,6 +270,22 @@ func resolveUpstreamTargetBranch(entry registry.Entry, repo model.RepoStatus, cf
 		}
 	}
 	return strings.TrimSpace(repo.Head.Branch)
+}
+
+// parseUpstreamRepairFilter validates the --only flag up front, mirroring
+// parseImportMode/parseOutputMode. Without this, an unrecognized value (e.g.
+// a typo) silently fell through repairUpstreamMatchesFilter's default arm as
+// "all", repairing tracking for every repo instead of failing loudly.
+func parseUpstreamRepairFilter(raw string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	switch normalized {
+	case "":
+		return "all", nil
+	case "all", "missing", "mismatch":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid --only %q (supported: all,missing,mismatch)", raw)
+	}
 }
 
 func repairUpstreamMatchesFilter(current, target, filter string) bool {

--- a/cmd/repokeeper/repair_upstream_test.go
+++ b/cmd/repokeeper/repair_upstream_test.go
@@ -67,6 +67,67 @@ func TestResolveUpstreamTargetBranch(t *testing.T) {
 	}
 }
 
+func TestParseUpstreamRepairFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to all", in: "", want: "all"},
+		{name: "all", in: "all", want: "all"},
+		{name: "missing", in: "missing", want: "missing"},
+		{name: "mismatch", in: "mismatch", want: "mismatch"},
+		{name: "case-insensitive and trimmed", in: "  MISMATCH  ", want: "mismatch"},
+		{
+			// Regression: an unrecognized --only value must be rejected, not
+			// silently treated as "all" (which would repair tracking for
+			// every repo instead of failing loudly on an operator typo).
+			name:    "unknown value is rejected",
+			in:      "unknown",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseUpstreamRepairFilter(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for input %q: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseUpstreamRepairFilter(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRepairUpstreamRunERejectsUnknownOnlyFilter(t *testing.T) {
+	cfgPath, _ := writeTestConfigAndRegistry(t)
+	cleanup := withTestConfig(t, cfgPath)
+	defer cleanup()
+
+	repairUpstreamCmd.SetContext(context.Background())
+	defer repairUpstreamCmd.SetOut(nil)
+	defer repairUpstreamCmd.SetErr(nil)
+	defer func() { _ = repairUpstreamCmd.Flags().Set("only", "all") }()
+
+	_ = repairUpstreamCmd.Flags().Set("registry", "")
+	_ = repairUpstreamCmd.Flags().Set("dry-run", "true")
+	_ = repairUpstreamCmd.Flags().Set("only", "bogus")
+	_ = repairUpstreamCmd.Flags().Set("format", "json")
+
+	err := repairUpstreamCmd.RunE(repairUpstreamCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid --only") {
+		t.Fatalf("expected invalid --only error, got %v", err)
+	}
+}
+
 func TestRepairUpstreamMatchesFilter(t *testing.T) {
 	if !repairUpstreamMatchesFilter("origin/main", "origin/main", "") {
 		t.Fatal("expected empty filter to match")

--- a/cmd/repokeeper/sync.go
+++ b/cmd/repokeeper/sync.go
@@ -115,7 +115,11 @@ var syncCmd = &cobra.Command{
 			return plan[i].RepoID < plan[j].RepoID
 		})
 		logOutputWriteFailure(cmd, "sync plan", writeSyncPlan(cmd, plan, cwd, []string{cfgRoot}))
-		if !yes && syncPlanNeedsConfirmation(plan) {
+		// --dry-run never applies any of the planned operations, so there is
+		// nothing to confirm. Prompting anyway means a non-interactive dry-run
+		// (e.g. piped stdin, -o json in CI) hits EOF/decline on the prompt and
+		// exits early without printing the plan output callers expect.
+		if !dryRun && !yes && syncPlanNeedsConfirmation(plan) {
 			confirmed, err := confirmSyncExecution(cmd)
 			if err != nil {
 				return err
@@ -162,6 +166,9 @@ var syncCmd = &cobra.Command{
 				}
 				return results[i].RepoID < results[j].RepoID
 			})
+			if err := persistSyncRegistryAfterCheckoutMissing(cfg, cfgPath, results); err != nil {
+				return err
+			}
 		}
 
 		switch mode.kind {
@@ -314,7 +321,9 @@ func syncPlanNeedsConfirmation(plan []engine.SyncResult) bool {
 }
 
 func syncResultNeedsConfirmation(res engine.SyncResult) bool {
-	// Confirmation is reserved for operations that mutate local state.
+	// Confirmation is reserved for operations that mutate local state or a
+	// remote (a --push-local push writes to the remote just as much as a
+	// rebase/stash/clone writes to the local checkout).
 	action := strings.ToLower(strings.TrimSpace(res.Action))
 	if strings.Contains(action, "pull --rebase") || strings.Contains(action, "stash push") {
 		return true
@@ -322,7 +331,33 @@ func syncResultNeedsConfirmation(res engine.SyncResult) bool {
 	if strings.Contains(action, "git clone") {
 		return true
 	}
+	if strings.Contains(action, "git push") {
+		return true
+	}
 	return false
+}
+
+// persistSyncRegistryAfterCheckoutMissing saves cfg's registry to disk when a
+// non-dry-run sync executed one or more successful --checkout-missing clones.
+// ExecuteSyncPlanWithCallbacks only updates the engine's in-memory registry
+// (cfg.Registry, since the same *registry.Registry is shared with the
+// engine); without an explicit save here the clone is never persisted, so
+// the next sync re-plans and re-attempts the same clone.
+func persistSyncRegistryAfterCheckoutMissing(cfg *config.Config, cfgPath string, results []engine.SyncResult) error {
+	if cfg == nil {
+		return nil
+	}
+	cloned := false
+	for _, res := range results {
+		if res.OK && res.Outcome == engine.SyncOutcomeCheckoutMissing {
+			cloned = true
+			break
+		}
+	}
+	if !cloned {
+		return nil
+	}
+	return config.Save(cfg, cfgPath)
 }
 
 type syncTableMode int
@@ -478,10 +513,10 @@ func (s *syncProgressWriter) writeProgressLine(state *syncProgressState, message
 		state.lastLen = len(line)
 		return nil
 	}
-	if newline {
-		_, err := fmt.Fprintf(s.cmd.OutOrStdout(), "%s\n", line)
-		return err
-	}
+	// Non-TTY output has no in-place cursor to return to, so there is no
+	// non-newline variant to emit: every call (progress tick or final
+	// result) writes exactly one line. `newline` only distinguishes
+	// behavior in the supportsInPlace branch above.
 	_, err := fmt.Fprintf(s.cmd.OutOrStdout(), "%s\n", line)
 	return err
 }


### PR DESCRIPTION
## Summary

Fixes 9 verified code-review findings across the CLI mutation commands (`add`, `move`, `edit`, `import`, `sync`, `repair-upstream`, `export`), plus dead-code cleanup where safe to do in-scope. One finding is partially deferred — see "Deferred" below.

## Findings fixed

1. **P1** `add.go`/`move.go` — `filepath.Abs(filepath.Join(cwd, target))` re-rooted an absolute target path under `cwd` (`filepath.Join` doesn't special-case absolute segments, so `Join("/cwd", "/abs/target")` → `/cwd/abs/target`). Added `resolveAbsoluteTargetPath`, mirroring `describe.go`'s absolute-first pattern: use an absolute target as-is (cleaned), otherwise join with cwd.
   - Tests: `TestResolveAbsoluteTargetPath`, `TestAddCommandWithAbsoluteTargetDoesNotReRootUnderCWD`, `TestMoveCommandWithAbsoluteTargetDoesNotReRootUnderCWD`.

2. **P1** `edit.go:202-208` `trackingBranchFromUpstream` split on `/` and returned the last segment, so `origin/feature/x` collapsed to `x`; `repair-upstream` then rewired tracking to `origin/x`. Fixed to strip only the first segment (the remote) via `strings.Cut`.
   - Test: `TestTrackingBranchFromUpstream` (table-driven, includes multi-segment branch case).

3. **P1** `import.go:112-134` — in merge mode, `--include-registry=false` still computed clone entries from the bundle and called `ExecuteImportClones`, which upserts every cloned entry into `cfg.Registry` regardless of `includeRegistry` — only `--file-only` previously suppressed cloning. Gated merge-mode cloning on `includeRegistry` explicitly (replace mode was already safe via `cfg.Registry == nil`).
   - Test: `TestImportCommandRunEMergeIncludeRegistryFalseDoesNotCloneOrRegisterBundleRepos` (verified it fails without the fix).

4. **P2** `sync.go:118-131` — `--dry-run` still ran the interactive confirmation before the dry-run branch, so a non-interactive dry-run (piped stdin, `-o json` in CI) hit EOF, was treated as declined, and exited without printing the plan. Confirmation is now skipped entirely when `--dry-run` is set.
   - Test: `TestSyncRunEDryRunSkipsConfirmationPrompt` (verified it fails without the fix).

5. **P2** `sync.go:316-326` `syncResultNeedsConfirmation` gated local rebase/stash/clone but not `git push`, so `--update-local --push-local` pushed to remotes with no prompt. Added `git push` to the gate.
   - Test: added cases to the existing `TestSyncResultNeedsConfirmationTable`.

6. **P2** `sync.go` — a successful `--checkout-missing` clone only updated the engine's in-memory registry; `sync` RunE never called `config.Save`, so the next run re-planned and re-attempted the same clone indefinitely. Registry is now persisted after a non-dry-run sync when any checkout-missing clone succeeded.
   - Test: `TestSyncRunEPersistsRegistryAfterCheckoutMissingClone` (verified it fails without the fix).

7. **P2** `edit.go:189-198` `validateEditedRegistryEntry` rejected an edit whenever *any* other entry shared its `repo_id`, breaking the supported multi-checkout case. Uniqueness is now keyed on `(repo_id, checkout_id)` when set, or `(repo_id, path)` otherwise.
   - Test: `TestValidateEditedRegistryEntryUniqueness` (table-driven).

8. **P2** `repair_upstream.go:271-282` `repairUpstreamMatchesFilter`'s default arm returned `true`, so an unrecognized `--only` value silently meant "all". Added `parseUpstreamRepairFilter` to validate `--only` up front (mirroring `parseImportMode`/`parseOutputMode`); `repairUpstreamMatchesFilter` itself is unchanged (its default is now unreachable from RunE).
   - Tests: `TestParseUpstreamRepairFilter`, `TestRepairUpstreamRunERejectsUnknownOnlyFilter`.

9. **P2** `export.go:91` wrote the bundle `0o644` with `entry.RemoteURL` verbatim, so credential URLs (`https://user:token@host/...`) leaked into a world-readable file. Now writes `0o600`; also warns (naming affected repo IDs) whenever an exported `remote_url` carries embedded credentials, reusing `urlutil.RedactCredentials` as the detector. `remote_url` is **not** redacted in the bundle body itself, since it must stay usable for `import`/`reconcile`.
   - Tests: `TestExportCommandRunEWritesFileOwnerOnlyPermissions`, `TestExportCommandRunEWarnsOnEmbeddedCredentials`, `TestExportEntriesWithEmbeddedCredentials`.

## Dead code (finding #10)

`sync.go:537` `writeSyncTable`'s `report *model.StatusReport` parameter and `sync.go:481-487` `writeProgressLine`'s `newline` param in the non-TTY branch:

- **`writeProgressLine`**: both non-TTY branches wrote the identical `"%s\n"` line, so `newline` had no effect there. **Removed** — collapsed to one statement (pure dedup, no behavior change; `newline` still matters in the in-place TTY branch above it).
- **`writeSyncTable`'s `report` param**: always `nil` at both call sites in `sync.go` (`:182`, `:187`), including via the `reconcile` alias (`kubectl_aliases.go` sets `reconcileCmd.RunE = syncCmd.RunE`), so the status-enrichment block and the `sync -o wide` `PRIMARY_REMOTE`/`UPSTREAM`/`AHEAD`/`BEHIND` columns never populate in production today. **Left as-is** for two reasons:
  1. The function's signature is exercised directly (with a non-nil report) by `helpers_test.go` and `terminal_width_test.go`, which are outside this PR's file scope — removing the parameter requires editing those.
  2. Wiring in a *real* report means running full per-repo `InspectRepo` on every plain `sync` call (today that only happens conditionally, e.g. under `--update-local` or certain `--only` filters), which is a behavior/perf change beyond a mutation-bug fix and needs its own decision, not a guess buried in this PR.

  A maintainer should decide: (a) wire `sync`/`reconcile` to build and pass a real `StatusReport` (accepting the added per-repo inspection cost), or (b) remove the dead parameter/columns outright (touching the two test files above). Flagging for follow-up rather than guessing.

## Tests added

Table-driven where the existing convention uses it; RunE-level regression tests reproduce each bug end-to-end and were confirmed to fail on the pre-fix code (verified for findings #1, #3, #4, #6, #9 by temporarily reverting each fix and re-running).

## Verification

```
go build ./...                                          # pass
go vet ./cmd/repokeeper/...                              # pass
go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./cmd/repokeeper/...   # pass
go test ./cmd/repokeeper/...                              # pass
go test -race ./cmd/repokeeper/...                        # pass, except a pre-existing, unrelated
                                                           # data race in internal/registry.backfillCheckoutID
                                                           # / internal/engine.InspectRepo, reachable via
                                                           # status.go's TestStatusRunE* tests. Reproduced this
                                                           # on a clean stash of origin/main (no changes from this
                                                           # PR) to confirm it predates this work — it's outside
                                                           # this PR's file scope (status.go, internal/engine,
                                                           # internal/registry) and looks like it belongs to a
                                                           # sibling in-flight PR touching status.go/scan.go.
                                                           # `go test -race ./cmd/repokeeper/... -skip TestStatusRunE`
                                                           # passes clean.
```

## Scope note

Per the task's file scope, only `cmd/repokeeper/{add,move,edit,import,sync,repair_upstream,export}.go` were changed for production code. Adding required test coverage unavoidably touched a few shared test files outside that literal list (none of the 7 production files have their own dedicated test file for every fix, and some of the functions being fixed already had table-driven tests living in shared files):

- `cmd/repokeeper/command_parsing_test.go` — appended 2 cases to the existing `TestSyncResultNeedsConfirmationTable` (git-push).
- `cmd/repokeeper/command_run_test.go` — added 2 new RunE-level sync tests (dry-run confirmation, checkout-missing persistence).
- `cmd/repokeeper/edit_test.go`, `export_test.go`, `import_test.go`, `move_test.go`, `repair_upstream_test.go` — each is the dedicated test file for one of the 7 production files; extended in place.
- `cmd/repokeeper/add_test.go` — new file (none existed for `add.go`).

None of these touch `status.go`, `scan.go`, `kubectl_aliases.go`, or their dedicated test files (`status_characterization_test.go`, `status_helpers_test.go`, `kubectl_aliases_test.go`), which are reserved for the sibling PR.