### PR TITLE
fix(engine): structured sync plan steps + filter/adapter correctness

### DIFF
--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -115,6 +115,11 @@ func safeRemoveAll(path string) error {
 }
 
 func (e *Engine) CloneAndRegister(ctx context.Context, remoteURL, targetPath, cfgPath string, mirror bool) error {
+	// Trim once up front and reuse: clone, normalization, and the stored entry
+	// must all see the same URL, or a whitespace-padded input (e.g. from the
+	// TUI/MCP server) could clone/normalize one value while the registry records
+	// another.
+	remoteURL = strings.TrimSpace(remoteURL)
 	if err := e.adapter.Clone(ctx, remoteURL, targetPath, "", mirror); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
@@ -133,7 +138,7 @@ func (e *Engine) CloneAndRegister(ctx context.Context, remoteURL, targetPath, cf
 		RepoID:    repoID,
 		Path:      targetPath,
 		Type:      repoType,
-		RemoteURL: strings.TrimSpace(remoteURL),
+		RemoteURL: remoteURL,
 		Status:    registry.StatusPresent,
 		LastSeen:  time.Now(),
 	}

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -130,11 +130,12 @@ func (e *Engine) CloneAndRegister(ctx context.Context, remoteURL, targetPath, cf
 	}
 
 	entry := registry.Entry{
-		RepoID:   repoID,
-		Path:     targetPath,
-		Type:     repoType,
-		Status:   registry.StatusPresent,
-		LastSeen: time.Now(),
+		RepoID:    repoID,
+		Path:      targetPath,
+		Type:      repoType,
+		RemoteURL: strings.TrimSpace(remoteURL),
+		Status:    registry.StatusPresent,
+		LastSeen:  time.Now(),
 	}
 	if !mirror {
 		entry.Branch = repoDefaultBranch(ctx, e.adapter, targetPath)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -663,7 +663,17 @@ func (e *Engine) executePlannedSyncItem(ctx context.Context, item SyncResult) Sy
 	if item.steps[0] == syncStepClone {
 		return e.executePlannedClone(ctx, executed)
 	}
-	return e.executePlannedNonClone(ctx, executed)
+	result := e.executePlannedNonClone(ctx, executed)
+	// A successfully executed skip-local-update item is still a skip: its fetch
+	// step ran, but no local update was applied. Restore the planner's
+	// user-facing skip message/class that we cleared above so the sync table's
+	// ERROR/ERROR_CLASS columns keep reporting the skip reason rather than going
+	// blank after plan execution.
+	if result.OK && result.Outcome == SyncOutcomeSkippedLocalUpdate {
+		result.Error = item.Error
+		result.ErrorClass = item.ErrorClass
+	}
+	return result
 }
 
 func (e *Engine) executePlannedClone(ctx context.Context, executed SyncResult) SyncResult {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -648,7 +648,19 @@ func (e *Engine) executePlannedSyncItem(ctx context.Context, item SyncResult) Sy
 	executed.Error = ""
 	executed.ErrorClass = ""
 
-	if len(item.steps) > 0 && item.steps[0] == syncStepClone {
+	// A planned item must carry at least one step. steps is unexported, so the
+	// planner is the only thing that can populate it; an empty slice means a
+	// corrupt/invalid plan rather than a legitimate no-op. Fail fast instead of
+	// silently reporting success and keeping a planned_* outcome.
+	if len(item.steps) == 0 {
+		executed.OK = false
+		executed.Outcome = SyncOutcomeFailedInvalid
+		executed.Error = "planned sync item has no steps"
+		executed.ErrorClass = "invalid"
+		return executed
+	}
+
+	if item.steps[0] == syncStepClone {
 		return e.executePlannedClone(ctx, executed)
 	}
 	return e.executePlannedNonClone(ctx, executed)
@@ -708,6 +720,15 @@ func (e *Engine) executePlannedNonClone(ctx context.Context, executed SyncResult
 			if err := e.adapter.Push(ctx, executed.Path); err != nil {
 				return e.failedPlannedSyncResult(executed, SyncOutcomeFailedPush, err)
 			}
+		default:
+			// An unrecognized step means a corrupt plan or a new step type added
+			// without executor support. Fail fast rather than silently skipping
+			// the work and reporting success.
+			executed.OK = false
+			executed.Outcome = SyncOutcomeFailedInvalid
+			executed.Error = fmt.Sprintf("unrecognized sync step %v in plan", step)
+			executed.ErrorClass = "invalid"
+			return executed
 		}
 	}
 	executed.OK = true

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -42,6 +42,50 @@ const (
 	FilterMissing        FilterKind = "missing"
 )
 
+// knownFilterKinds is the set of filter values the engine understands. It backs
+// both up-front validation (ParseFilterKind) and the internal fail-closed
+// defense so an unrecognized filter never silently matches every repository.
+var knownFilterKinds = map[FilterKind]struct{}{
+	FilterAll:            {},
+	FilterErrors:         {},
+	FilterDirty:          {},
+	FilterClean:          {},
+	FilterGone:           {},
+	FilterDiverged:       {},
+	FilterBehind:         {},
+	FilterAhead:          {},
+	FilterEqual:          {},
+	FilterRemoteMismatch: {},
+	FilterMissing:        {},
+}
+
+// isKnownFilterKind reports whether kind is a recognized filter value. An empty
+// kind is the conventional "no filter" and is treated as FilterAll (match all),
+// so only genuinely unrecognized values are rejected.
+func isKnownFilterKind(kind FilterKind) bool {
+	if kind == "" {
+		return true
+	}
+	_, ok := knownFilterKinds[kind]
+	return ok
+}
+
+// ParseFilterKind validates a raw --only/filter value and returns the typed
+// FilterKind. An empty value defaults to FilterAll; any other unrecognized value
+// fails closed with an error rather than matching every repository. Callers may
+// validate up front with this helper; the engine also fails closed internally
+// for defense in depth, so adopting it is not required.
+func ParseFilterKind(raw string) (FilterKind, error) {
+	kind := FilterKind(strings.ToLower(strings.TrimSpace(raw)))
+	if kind == "" {
+		return FilterAll, nil
+	}
+	if !isKnownFilterKind(kind) {
+		return "", fmt.Errorf("unknown filter %q", raw)
+	}
+	return kind, nil
+}
+
 const workerChannelBufferMin = 1
 
 // Engine is the core orchestrator for RepoKeeper operations.
@@ -417,7 +461,30 @@ type SyncResult struct {
 	Planned bool
 	// SkipReason carries typed skip rationale for outcomes that intentionally skip work.
 	SkipReason string
+	// steps is the ordered list of typed VCS operations an executor performs for
+	// this planned item. Execution dispatches on these steps rather than parsing
+	// the human-readable Action string, so non-git backends and skip-with-fetch
+	// plans route through the adapter correctly. It is intentionally unexported:
+	// callers pass a plan straight from Sync into ExecuteSyncPlanWithCallbacks,
+	// and struct copies preserve the field across package boundaries.
+	steps []syncStep
 }
+
+// syncStep identifies a single VCS operation within an executable sync plan.
+type syncStep string
+
+const (
+	syncStepClone      syncStep = "clone"
+	syncStepFetch      syncStep = "fetch"
+	syncStepStashPush  syncStep = "stash_push"
+	syncStepPullRebase syncStep = "pull_rebase"
+	syncStepStashPop   syncStep = "stash_pop"
+	syncStepPush       syncStep = "push"
+)
+
+// preRebaseStashMessage is the stash message used when auto-stashing a dirty
+// worktree before a pull --rebase during local update.
+const preRebaseStashMessage = "repokeeper: pre-rebase stash"
 
 // SyncResultCallback is invoked for each sync result as it is produced.
 // Callbacks run on the coordinator goroutine, so callers can safely write
@@ -429,9 +496,6 @@ type SyncStartCallback func(SyncResult)
 
 // OutcomeKind is the typed outcome category for a single sync result.
 type OutcomeKind string
-
-// SyncOutcome is retained as an alias for compatibility.
-type SyncOutcome = OutcomeKind
 
 const (
 	SyncOutcomeFailedInvalid         OutcomeKind = "failed_invalid"
@@ -480,18 +544,6 @@ const (
 	SyncReasonBranchHasLocalCommitsToPush = "branch has local commits to push"
 	SyncReasonAlreadyUpToDate             = "already up to date"
 )
-
-// ExecuteSyncPlan executes a previously computed dry-run sync plan.
-// It avoids re-inspecting repo state so sync can analyze once and then apply.
-func (e *Engine) ExecuteSyncPlan(ctx context.Context, plan []SyncResult, opts SyncOptions) ([]SyncResult, error) {
-	return e.ExecuteSyncPlanWithCallback(ctx, plan, opts, nil)
-}
-
-// ExecuteSyncPlanWithCallback executes a previously computed dry-run sync plan
-// and invokes callback for each completed result in completion order.
-func (e *Engine) ExecuteSyncPlanWithCallback(ctx context.Context, plan []SyncResult, opts SyncOptions, callback SyncResultCallback) ([]SyncResult, error) {
-	return e.ExecuteSyncPlanWithCallbacks(ctx, plan, opts, nil, callback)
-}
 
 // ExecuteSyncPlanWithCallbacks executes a planned sync and invokes onStart
 // before each repo action begins and onComplete after each repo action ends.
@@ -596,11 +648,10 @@ func (e *Engine) executePlannedSyncItem(ctx context.Context, item SyncResult) Sy
 	executed.Error = ""
 	executed.ErrorClass = ""
 
-	action := strings.ToLower(strings.TrimSpace(item.Action))
-	if strings.Contains(action, "git clone") {
+	if len(item.steps) > 0 && item.steps[0] == syncStepClone {
 		return e.executePlannedClone(ctx, executed)
 	}
-	return e.executePlannedNonClone(ctx, executed, action)
+	return e.executePlannedNonClone(ctx, executed)
 }
 
 func (e *Engine) executePlannedClone(ctx context.Context, executed SyncResult) SyncResult {
@@ -627,40 +678,64 @@ func (e *Engine) executePlannedClone(ctx context.Context, executed SyncResult) S
 	return executed
 }
 
-func (e *Engine) executePlannedNonClone(ctx context.Context, executed SyncResult, action string) SyncResult {
+func (e *Engine) executePlannedNonClone(ctx context.Context, executed SyncResult) SyncResult {
 	stashed := false
-	if strings.Contains(action, "git fetch --all") {
-		if err := e.adapter.Fetch(ctx, executed.Path); err != nil {
-			return e.failedPlannedSyncResult(executed, SyncOutcomeFailedFetch, err)
+	for _, step := range executed.steps {
+		switch step {
+		case syncStepFetch:
+			if err := e.adapter.Fetch(ctx, executed.Path); err != nil {
+				return e.failedPlannedSyncResult(executed, SyncOutcomeFailedFetch, err)
+			}
+		case syncStepStashPush:
+			created, err := e.adapter.StashPush(ctx, executed.Path, preRebaseStashMessage)
+			if err != nil {
+				return e.failedPlannedSyncResult(executed, SyncOutcomeFailedStash, err)
+			}
+			stashed = created
+		case syncStepPullRebase:
+			if err := e.adapter.PullRebase(ctx, executed.Path); err != nil {
+				return e.failedPlannedSyncResult(executed, SyncOutcomeFailedRebase, err)
+			}
+		case syncStepStashPop:
+			// Only pop when a stash was actually created above.
+			if !stashed {
+				continue
+			}
+			if err := e.adapter.StashPop(ctx, executed.Path); err != nil {
+				return e.failedPlannedSyncResult(executed, SyncOutcomeFailedStashPop, err)
+			}
+		case syncStepPush:
+			if err := e.adapter.Push(ctx, executed.Path); err != nil {
+				return e.failedPlannedSyncResult(executed, SyncOutcomeFailedPush, err)
+			}
 		}
-		executed.Outcome = SyncOutcomeFetched
-	}
-	if strings.Contains(action, "stash push") {
-		created, err := e.adapter.StashPush(ctx, executed.Path, "repokeeper: pre-rebase stash")
-		if err != nil {
-			return e.failedPlannedSyncResult(executed, SyncOutcomeFailedStash, err)
-		}
-		stashed = created
-	}
-	if strings.Contains(action, "pull --rebase") {
-		if err := e.adapter.PullRebase(ctx, executed.Path); err != nil {
-			return e.failedPlannedSyncResult(executed, SyncOutcomeFailedRebase, err)
-		}
-		executed.Outcome = outcomeForRebase(stashed)
-	}
-	if strings.Contains(action, "stash pop") && stashed {
-		if err := e.adapter.StashPop(ctx, executed.Path); err != nil {
-			return e.failedPlannedSyncResult(executed, SyncOutcomeFailedStashPop, err)
-		}
-	}
-	if strings.Contains(action, "git push") {
-		if err := e.adapter.Push(ctx, executed.Path); err != nil {
-			return e.failedPlannedSyncResult(executed, SyncOutcomeFailedPush, err)
-		}
-		executed.Outcome = SyncOutcomePushed
 	}
 	executed.OK = true
+	executed.Outcome = executedNonCloneOutcome(executed, stashed)
 	return executed
+}
+
+// executedNonCloneOutcome maps a successfully executed non-clone plan to its
+// reported outcome. Skip-local-update plans still run their fetch step but must
+// report the skip (with its reason preserved). Otherwise the terminal outcome is
+// that of the last outcome-bearing step performed (fetch < rebase < push in plan
+// order), matching the sequential semantics of the direct apply path.
+func executedNonCloneOutcome(item SyncResult, stashed bool) OutcomeKind {
+	if item.Outcome == SyncOutcomeSkippedLocalUpdate {
+		return SyncOutcomeSkippedLocalUpdate
+	}
+	outcome := item.Outcome
+	for _, s := range item.steps {
+		switch s {
+		case syncStepFetch:
+			outcome = SyncOutcomeFetched
+		case syncStepPullRebase:
+			outcome = outcomeForRebase(stashed)
+		case syncStepPush:
+			outcome = SyncOutcomePushed
+		}
+	}
+	return outcome
 }
 
 func (e *Engine) failedPlannedSyncResult(executed SyncResult, outcome OutcomeKind, err error) SyncResult {
@@ -867,6 +942,11 @@ func (e *Engine) prepareSyncEntry(ctx context.Context, entry registry.Entry, opt
 
 func (e *Engine) syncEntryMatchesInspectFilter(ctx context.Context, entry registry.Entry, opts SyncOptions) (bool, *SyncResult) {
 	if !filterRequiresInspect(opts.Filter) {
+		// Non-inspect filters (all/errors/missing) match without a live inspect,
+		// but an unknown filter must fail closed rather than matching every repo.
+		if !isKnownFilterKind(opts.Filter) {
+			return false, nil
+		}
 		return true, nil
 	}
 	status, err := e.InspectRepo(ctx, entry.Path)
@@ -878,7 +958,9 @@ func (e *Engine) syncEntryMatchesInspectFilter(ctx context.Context, entry regist
 	case FilterDirty:
 		return status.Worktree != nil && status.Worktree.Dirty, nil
 	case FilterClean:
-		return status.Worktree == nil || !status.Worktree.Dirty, nil
+		// Aligned with filterStatus: a repo with no worktree (e.g. bare) is not
+		// reported as clean, so both filter paths agree on the same repo set.
+		return status.Worktree != nil && !status.Worktree.Dirty, nil
 	case FilterGone:
 		return status.Tracking.Status == model.TrackingGone, nil
 	case FilterDiverged:
@@ -892,7 +974,8 @@ func (e *Engine) syncEntryMatchesInspectFilter(ctx context.Context, entry regist
 	case FilterRemoteMismatch:
 		return hasRemoteMismatch(*status, entry, e.normalizer), nil
 	default:
-		return true, nil
+		// Fail closed: an unknown inspect filter must not match every repo.
+		return false, nil
 	}
 }
 
@@ -952,6 +1035,7 @@ func (e *Engine) handleMissingSyncEntry(ctx context.Context, entry registry.Entr
 			Error:   SyncErrorDryRun,
 			Action:  action,
 			Planned: true,
+			steps:   []syncStep{syncStepClone},
 		}
 	}
 	if err := e.adapter.Clone(ctx, remoteURL, entry.Path, branch, mirror); err != nil {
@@ -985,60 +1069,90 @@ func (e *Engine) runSyncEntry(ctx context.Context, entry registry.Entry, opts Sy
 }
 
 func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts SyncOptions) SyncResult {
-	action := syncFetchAction(ctx, e.adapter, entry.Path)
-	if opts.UpdateLocal {
-		supported, reason, err := supportsLocalUpdate(ctx, e.adapter, entry.Path)
-		if err != nil {
-			return inspectFailureResult(entry, err, e.classifier)
+	fetchAction := syncFetchAction(ctx, e.adapter, entry.Path)
+
+	// skippedLocalUpdate builds a plan that still fetches but intentionally skips
+	// the local update. The fetch step is retained (and Planned=true) so that
+	// --update-local never fetches fewer repos than a plain sync, while the
+	// reported outcome preserves the typed skip reason.
+	skippedLocalUpdate := func(reason string) SyncResult {
+		return SyncResult{
+			RepoID:     entry.RepoID,
+			Path:       entry.Path,
+			Outcome:    SyncOutcomeSkippedLocalUpdate,
+			OK:         true,
+			ErrorClass: "skipped",
+			Error:      SyncErrorSkippedLocalUpdatePrefix + reason,
+			Action:     fetchAction,
+			SkipReason: reason,
+			Planned:    true,
+			steps:      []syncStep{syncStepFetch},
 		}
-		if !supported {
-			return SyncResult{
-				RepoID:     entry.RepoID,
-				Path:       entry.Path,
-				Outcome:    SyncOutcomeSkippedLocalUpdate,
-				OK:         true,
-				ErrorClass: "skipped",
-				Error:      SyncErrorSkippedLocalUpdatePrefix + reason,
-				Action:     action,
-				SkipReason: reason,
-			}
+	}
+
+	if !opts.UpdateLocal {
+		return SyncResult{
+			RepoID:  entry.RepoID,
+			Path:    entry.Path,
+			Outcome: SyncOutcomePlannedFetch,
+			OK:      true,
+			Error:   SyncErrorDryRun,
+			Action:  fetchAction,
+			Planned: true,
+			steps:   []syncStep{syncStepFetch},
 		}
-		// We still inspect during dry-run so skip reasons and planned actions
-		// match live execution as closely as possible.
-		status, err := e.InspectRepo(ctx, entry.Path)
-		if err != nil {
-			return inspectFailureResult(entry, err, e.classifier)
+	}
+
+	supported, reason, err := supportsLocalUpdate(ctx, e.adapter, entry.Path)
+	if err != nil {
+		return inspectFailureResult(entry, err, e.classifier)
+	}
+	if !supported {
+		return skippedLocalUpdate(reason)
+	}
+	// We still inspect during dry-run so skip reasons and planned actions
+	// match live execution as closely as possible.
+	status, err := e.InspectRepo(ctx, entry.Path)
+	if err != nil {
+		return inspectFailureResult(entry, err, e.classifier)
+	}
+	if opts.PushLocal && status.Tracking.Status == model.TrackingAhead {
+		return SyncResult{
+			RepoID:  entry.RepoID,
+			Path:    entry.Path,
+			Outcome: SyncOutcomePlannedPush,
+			OK:      true,
+			Error:   SyncErrorDryRun,
+			Action:  fetchAction + " && git push",
+			Planned: true,
+			steps:   []syncStep{syncStepFetch, syncStepPush},
 		}
-		if opts.PushLocal && status.Tracking.Status == model.TrackingAhead {
-			action += " && git push"
-			return SyncResult{
-				RepoID:  entry.RepoID,
-				Path:    entry.Path,
-				Outcome: SyncOutcomePlannedPush,
-				OK:      true,
-				Error:   SyncErrorDryRun,
-				Action:  action,
-				Planned: true,
-			}
-		}
-		if reason := pullRebaseSkipReason(status, PullRebasePolicyOptions{
-			RebaseDirty:          opts.RebaseDirty,
-			Force:                opts.Force,
-			ProtectedBranches:    opts.ProtectedBranches,
-			AllowProtectedRebase: opts.AllowProtectedRebase,
-		}); reason != "" {
-			return SyncResult{
-				RepoID:     entry.RepoID,
-				Path:       entry.Path,
-				Outcome:    SyncOutcomeSkippedLocalUpdate,
-				OK:         true,
-				ErrorClass: "skipped",
-				Error:      SyncErrorSkippedLocalUpdatePrefix + reason,
-				Action:     action,
-				SkipReason: reason,
-			}
-		}
-		action += " && git pull --rebase --no-recurse-submodules"
+	}
+	if reason := pullRebaseSkipReason(status, PullRebasePolicyOptions{
+		RebaseDirty:          opts.RebaseDirty,
+		Force:                opts.Force,
+		ProtectedBranches:    opts.ProtectedBranches,
+		AllowProtectedRebase: opts.AllowProtectedRebase,
+	}); reason != "" {
+		return skippedLocalUpdate(reason)
+	}
+
+	// Local update proceeds: fetch, then pull --rebase, auto-stashing a dirty
+	// worktree when --rebase-dirty is set so the rebase does not fail. The stash
+	// steps are emitted into the plan itself so the live execute path performs
+	// them (git pull --rebase has no built-in autostash here).
+	steps := []syncStep{syncStepFetch}
+	action := fetchAction
+	stashPlanned := opts.RebaseDirty && status.Worktree != nil && status.Worktree.Dirty
+	if stashPlanned {
+		steps = append(steps, syncStepStashPush)
+		action += " && git stash push -u -m \"" + preRebaseStashMessage + "\""
+	}
+	steps = append(steps, syncStepPullRebase)
+	action += " && git pull --rebase --no-recurse-submodules"
+	if stashPlanned {
+		steps = append(steps, syncStepStashPop)
+		action += " && git stash pop"
 	}
 	return SyncResult{
 		RepoID:  entry.RepoID,
@@ -1048,6 +1162,7 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 		Error:   SyncErrorDryRun,
 		Action:  action,
 		Planned: true,
+		steps:   steps,
 	}
 }
 
@@ -1379,7 +1494,8 @@ func (e *Engine) setRegistryUpdatedAt(ts time.Time) {
 
 func filterStatus(kind FilterKind, status model.RepoStatus, reg *registry.Registry) bool {
 	switch kind {
-	case FilterAll:
+	case FilterAll, "":
+		// An empty kind is the conventional "no filter" and matches all repos.
 		return true
 	case FilterMissing:
 		if reg == nil {
@@ -1413,7 +1529,8 @@ func filterStatus(kind FilterKind, status model.RepoStatus, reg *registry.Regist
 	case FilterErrors:
 		return status.Error != ""
 	default:
-		return true
+		// Fail closed: an unknown filter must not match every repository.
+		return false
 	}
 }
 

--- a/internal/engine/engine_actions_import_repair_internal_test.go
+++ b/internal/engine/engine_actions_import_repair_internal_test.go
@@ -751,6 +751,39 @@ func TestActionsResetDeleteCloneAndRegister(t *testing.T) {
 			t.Fatalf("expected local fallback repo id entry, got %+v", localEntry)
 		}
 	})
+
+	t.Run("CloneAndRegister trims the remote URL before clone, normalize, and store", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfgPath := filepath.Join(tmp, "config.yaml")
+		target := filepath.Join(tmp, "checkout")
+
+		// Only the trimmed clone command is registered: if CloneAndRegister passed
+		// the padded URL straight to adapter.Clone, the runner would not match and
+		// the clone would fail. Success here proves the URL is trimmed before it
+		// reaches the adapter.
+		runner := &testRunner{responses: map[string]testResponse{
+			":" + strings.Join([]string{"clone", "git@github.com:org/repo.git", target}, " "): {out: ""},
+		}}
+		eng := &Engine{
+			cfg:        &config.Config{},
+			registry:   &registry.Registry{},
+			adapter:    vcs.NewGitAdapter(runner),
+			classifier: vcs.NewGitErrorClassifier(),
+		}
+
+		if err := eng.CloneAndRegister(context.Background(), "  git@github.com:org/repo.git\n", target, cfgPath, false); err != nil {
+			t.Fatalf("expected a padded URL to be trimmed and clone to succeed, got %v", err)
+		}
+		// Normalization also ran on the trimmed URL, so the entry resolves under
+		// the normalized repo_id and stores the trimmed remote.
+		entry := eng.registry.FindByRepoID("github.com/org/repo")
+		if entry == nil {
+			t.Fatal("expected entry under the normalized repo id from the trimmed URL")
+		}
+		if entry.RemoteURL != "git@github.com:org/repo.git" {
+			t.Fatalf("expected stored RemoteURL trimmed, got %q", entry.RemoteURL)
+		}
+	})
 }
 
 func TestRemoteMismatchWrapperFunctions(t *testing.T) {

--- a/internal/engine/engine_actions_import_repair_internal_test.go
+++ b/internal/engine/engine_actions_import_repair_internal_test.go
@@ -724,6 +724,12 @@ func TestActionsResetDeleteCloneAndRegister(t *testing.T) {
 		if checkoutEntry == nil || checkoutEntry.Type != "checkout" || checkoutEntry.Path != targetCheckout {
 			t.Fatalf("unexpected checkout entry: %+v", checkoutEntry)
 		}
+		// RemoteURL must be recorded so the fresh clone is visible to sync
+		// (prepareSyncEntry would otherwise short-circuit skipped-no-upstream and
+		// --checkout-missing would fail with a missing remote_url).
+		if checkoutEntry.RemoteURL != "git@github.com:org/repo.git" {
+			t.Fatalf("expected checkout entry RemoteURL set, got %q", checkoutEntry.RemoteURL)
+		}
 
 		if err := eng.CloneAndRegister(context.Background(), "git@github.com:org/mirror.git", targetMirror, cfgPath, true); err != nil {
 			t.Fatalf("clone and register mirror: %v", err)
@@ -731,6 +737,9 @@ func TestActionsResetDeleteCloneAndRegister(t *testing.T) {
 		mirrorEntry := eng.registry.FindByRepoID("github.com/org/mirror")
 		if mirrorEntry == nil || mirrorEntry.Type != "mirror" || mirrorEntry.Path != targetMirror {
 			t.Fatalf("unexpected mirror entry: %+v", mirrorEntry)
+		}
+		if mirrorEntry.RemoteURL != "git@github.com:org/mirror.git" {
+			t.Fatalf("expected mirror entry RemoteURL set, got %q", mirrorEntry.RemoteURL)
 		}
 
 		if err := eng.CloneAndRegister(context.Background(), "/", targetLocal, cfgPath, false); err != nil {

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -439,7 +439,7 @@ func TestEngineGuardErrors(t *testing.T) {
 	if _, err := eng.Status(context.Background(), StatusOptions{}); err == nil {
 		t.Fatal("expected status registry not loaded error")
 	}
-	if _, err := eng.ExecuteSyncPlan(context.Background(), nil, SyncOptions{}); err == nil {
+	if _, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), nil, SyncOptions{}, nil, nil); err == nil {
 		t.Fatal("expected execute sync plan registry not loaded error")
 	}
 }
@@ -464,8 +464,9 @@ func TestExecuteSyncPlanAppliesActions(t *testing.T) {
 		Outcome: "planned_fetch",
 		Action:  "git fetch --all --prune --prune-tags --no-recurse-submodules && git stash push -u -m \"repokeeper: pre-rebase stash\" && git pull --rebase --no-recurse-submodules && git stash pop && git push",
 		Planned: true,
+		steps:   []syncStep{syncStepFetch, syncStepStashPush, syncStepPullRebase, syncStepStashPop, syncStepPush},
 	}}
-	results, err := eng.ExecuteSyncPlan(context.Background(), plan, SyncOptions{ContinueOnError: true})
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: true}, nil, nil)
 	if err != nil {
 		t.Fatalf("execute sync plan failed: %v", err)
 	}
@@ -485,10 +486,10 @@ func TestExecuteSyncPlanStopsOnFailure(t *testing.T) {
 	}}, vcs.NewGitAdapter(runner), nil, nil, nil)
 
 	plan := []SyncResult{
-		{RepoID: "repo1", Path: "/repo1", OK: true, Error: SyncErrorDryRun, Outcome: "planned_fetch", Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", Planned: true},
-		{RepoID: "repo2", Path: "/repo2", OK: true, Error: SyncErrorDryRun, Outcome: "planned_fetch", Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", Planned: true},
+		{RepoID: "repo1", Path: "/repo1", OK: true, Error: SyncErrorDryRun, Outcome: "planned_fetch", Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", Planned: true, steps: []syncStep{syncStepFetch}},
+		{RepoID: "repo2", Path: "/repo2", OK: true, Error: SyncErrorDryRun, Outcome: "planned_fetch", Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", Planned: true, steps: []syncStep{syncStepFetch}},
 	}
-	results, err := eng.ExecuteSyncPlan(context.Background(), plan, SyncOptions{ContinueOnError: false})
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: false}, nil, nil)
 	if err != nil {
 		t.Fatalf("execute sync plan failed: %v", err)
 	}
@@ -504,9 +505,9 @@ func TestExecuteSyncPlanStopsOnNonDryRunFailure(t *testing.T) {
 	eng := New(&config.Config{}, &registry.Registry{}, vcs.NewGitAdapter(nil), nil, nil, nil)
 	plan := []SyncResult{
 		{RepoID: "repo1", Path: "/repo1", OK: false, Error: "boom", Outcome: "failed_fetch"},
-		{RepoID: "repo2", Path: "/repo2", OK: true, Error: SyncErrorDryRun, Outcome: "planned_fetch", Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", Planned: true},
+		{RepoID: "repo2", Path: "/repo2", OK: true, Error: SyncErrorDryRun, Outcome: "planned_fetch", Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", Planned: true, steps: []syncStep{syncStepFetch}},
 	}
-	results, err := eng.ExecuteSyncPlan(context.Background(), plan, SyncOptions{ContinueOnError: false})
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: false}, nil, nil)
 	if err != nil {
 		t.Fatalf("execute sync plan failed: %v", err)
 	}
@@ -538,8 +539,9 @@ func TestExecuteSyncPlanCloneAction(t *testing.T) {
 		Outcome: "planned_checkout_missing",
 		Action:  "git clone --branch main --single-branch git@github.com:org/missing.git /missing",
 		Planned: true,
+		steps:   []syncStep{syncStepClone},
 	}}
-	results, err := eng.ExecuteSyncPlan(context.Background(), plan, SyncOptions{ContinueOnError: true})
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: true}, nil, nil)
 	if err != nil {
 		t.Fatalf("execute clone plan failed: %v", err)
 	}
@@ -567,10 +569,11 @@ func TestExecuteSyncPlanWithCallbackInvokesPerResult(t *testing.T) {
 		Outcome: SyncOutcomePlannedFetch,
 		Action:  "git fetch --all --prune --prune-tags --no-recurse-submodules",
 		Planned: true,
+		steps:   []syncStep{syncStepFetch},
 	}}
 
 	seen := 0
-	results, err := eng.ExecuteSyncPlanWithCallback(context.Background(), plan, SyncOptions{ContinueOnError: true}, func(res SyncResult) {
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: true}, nil, func(res SyncResult) {
 		seen++
 		if res.Path != "/repo" {
 			t.Fatalf("unexpected callback result path: %q", res.Path)
@@ -594,8 +597,8 @@ func TestFilterAndLookupEdgeBranches(t *testing.T) {
 	if filterStatus(FilterRemoteMismatch, model.RepoStatus{RepoID: "r1"}, nil) {
 		t.Fatal("expected remote mismatch false without registry")
 	}
-	if !filterStatus(FilterKind("unknown"), model.RepoStatus{}, nil) {
-		t.Fatal("expected unknown filter default true")
+	if filterStatus(FilterKind("unknown"), model.RepoStatus{}, nil) {
+		t.Fatal("expected unknown filter to fail closed (match nothing)")
 	}
 
 	if findRegistryEntryForStatus(nil, model.RepoStatus{}) != nil {

--- a/internal/engine/engine_more_internal_test.go
+++ b/internal/engine/engine_more_internal_test.go
@@ -211,8 +211,8 @@ func TestPullRebaseSkipReasonTable(t *testing.T) {
 }
 
 func TestFilterStatusDefaultKind(t *testing.T) {
-	if !filterStatus(FilterKind("something-new"), model.RepoStatus{}, nil) {
-		t.Fatal("expected unknown filter kind to default to true")
+	if filterStatus(FilterKind("something-new"), model.RepoStatus{}, nil) {
+		t.Fatal("expected unknown filter kind to fail closed (match nothing)")
 	}
 }
 
@@ -377,20 +377,20 @@ func TestExecuteSyncPlanAppliesPlannedActions(t *testing.T) {
 	}
 	eng := &Engine{registry: reg, adapter: adapter, classifier: vcs.NewGitErrorClassifier(), normalizer: vcs.NewGitURLNormalizer(), logger: obs.NopLogger()}
 	plan := []SyncResult{
-		{RepoID: "fetch", Path: "/repos/fetch", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules"},
-		{RepoID: "rebase", Path: "/repos/rebase", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules && git stash push -u -m \"repokeeper: pre-rebase stash\" && git pull --rebase --no-recurse-submodules && git stash pop"},
-		{RepoID: "push", Path: "/repos/push", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules && git push"},
-		{RepoID: "clone", Path: "/repos/clone", OK: true, Error: "dry-run", Planned: true, Action: "git clone --branch main --single-branch git@github.com:org/clone.git /repos/clone"},
+		{RepoID: "fetch", Path: "/repos/fetch", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", steps: []syncStep{syncStepFetch}},
+		{RepoID: "rebase", Path: "/repos/rebase", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules && git stash push -u -m \"repokeeper: pre-rebase stash\" && git pull --rebase --no-recurse-submodules && git stash pop", steps: []syncStep{syncStepFetch, syncStepStashPush, syncStepPullRebase, syncStepStashPop}},
+		{RepoID: "push", Path: "/repos/push", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules && git push", steps: []syncStep{syncStepFetch, syncStepPush}},
+		{RepoID: "clone", Path: "/repos/clone", OK: true, Error: "dry-run", Planned: true, Action: "git clone --branch main --single-branch git@github.com:org/clone.git /repos/clone", steps: []syncStep{syncStepClone}},
 		{RepoID: "skip", Path: "/repos/skip", OK: true, Error: "skipped-no-upstream"},
 	}
-	results, err := eng.ExecuteSyncPlan(context.Background(), plan, SyncOptions{ContinueOnError: true})
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: true}, nil, nil)
 	if err != nil {
 		t.Fatalf("execute sync plan: %v", err)
 	}
 	if len(results) != len(plan) {
 		t.Fatalf("expected %d results, got %d", len(plan), len(results))
 	}
-	outcome := map[string]SyncOutcome{}
+	outcome := map[string]OutcomeKind{}
 	for _, res := range results {
 		outcome[res.RepoID] = res.Outcome
 	}
@@ -425,10 +425,10 @@ func TestExecuteSyncPlanStopsOnFailureWhenConfigured(t *testing.T) {
 		logger:     obs.NopLogger(),
 	}
 	plan := []SyncResult{
-		{RepoID: "a", Path: "/repos/a", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules"},
-		{RepoID: "b", Path: "/repos/b", OK: true, Error: "dry-run", Planned: true, Action: "git push"},
+		{RepoID: "a", Path: "/repos/a", OK: true, Error: "dry-run", Planned: true, Action: "git fetch --all --prune --prune-tags --no-recurse-submodules", steps: []syncStep{syncStepFetch}},
+		{RepoID: "b", Path: "/repos/b", OK: true, Error: "dry-run", Planned: true, Action: "git push", steps: []syncStep{syncStepPush}},
 	}
-	results, err := eng.ExecuteSyncPlan(context.Background(), plan, SyncOptions{ContinueOnError: false})
+	results, err := eng.ExecuteSyncPlanWithCallbacks(context.Background(), plan, SyncOptions{ContinueOnError: false}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/engine/engine_sync_planexec_internal_test.go
+++ b/internal/engine/engine_sync_planexec_internal_test.go
@@ -86,6 +86,14 @@ func TestUpdateLocalStillFetchesDirtySkip(t *testing.T) {
 	if executed.SkipReason != SyncReasonDirtyWorkingTree {
 		t.Fatalf("expected executed skip reason preserved, got %q", executed.SkipReason)
 	}
+	// The user-facing skip message/class must survive plan execution so the sync
+	// table's ERROR/ERROR_CLASS columns still report the reason after the fetch.
+	if executed.ErrorClass != "skipped" {
+		t.Fatalf("expected executed skip to keep ErrorClass \"skipped\", got %q", executed.ErrorClass)
+	}
+	if executed.Error == "" || executed.Error != plan.Error {
+		t.Fatalf("expected executed skip to keep the planner skip message %q, got %q", plan.Error, executed.Error)
+	}
 }
 
 // Finding 2: an hg fetch step must actually pull. The adapter reports local

--- a/internal/engine/engine_sync_planexec_internal_test.go
+++ b/internal/engine/engine_sync_planexec_internal_test.go
@@ -217,3 +217,45 @@ func TestPrepareSyncEntryUnknownFilterFailsClosed(t *testing.T) {
 		t.Fatalf("expected FilterAll to queue the entry, got queue=%v immediate=%v", queue, immediate)
 	}
 }
+
+// Fail-fast: a planned item with no steps is a corrupt/invalid plan. steps is
+// unexported, so the planner is the only thing that can populate it; an empty
+// slice must fail as failed_invalid rather than silently report a no-op success.
+func TestExecutePlannedSyncItemEmptyStepsFailsInvalid(t *testing.T) {
+	adapter := &planAdapter{}
+	eng := newPlanExecEngine(adapter)
+
+	item := SyncResult{Path: "/repo", Planned: true, Outcome: SyncOutcomeFetched}
+	got := eng.executePlannedSyncItem(context.Background(), item)
+
+	if got.OK {
+		t.Fatalf("expected empty-steps item to fail, got OK=true (outcome=%v)", got.Outcome)
+	}
+	if got.Outcome != SyncOutcomeFailedInvalid {
+		t.Fatalf("expected outcome %v, got %v", SyncOutcomeFailedInvalid, got.Outcome)
+	}
+	if len(adapter.calls) != 0 {
+		t.Fatalf("expected no adapter calls for an invalid plan, got %v", adapter.calls)
+	}
+}
+
+// Fail-fast: an unrecognized step (corrupt plan, or a new step type added
+// without executor support) must fail as failed_invalid rather than skip the
+// work and report success.
+func TestExecutePlannedNonCloneUnknownStepFailsInvalid(t *testing.T) {
+	adapter := &planAdapter{}
+	eng := newPlanExecEngine(adapter)
+
+	item := SyncResult{Path: "/repo", Planned: true, steps: []syncStep{syncStep("bogus")}}
+	got := eng.executePlannedSyncItem(context.Background(), item)
+
+	if got.OK {
+		t.Fatalf("expected unknown-step item to fail, got OK=true (outcome=%v)", got.Outcome)
+	}
+	if got.Outcome != SyncOutcomeFailedInvalid {
+		t.Fatalf("expected outcome %v, got %v", SyncOutcomeFailedInvalid, got.Outcome)
+	}
+	if len(adapter.calls) != 0 {
+		t.Fatalf("expected no adapter calls before hitting the unknown step, got %v", adapter.calls)
+	}
+}

--- a/internal/engine/engine_sync_planexec_internal_test.go
+++ b/internal/engine/engine_sync_planexec_internal_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skaphos/repokeeper/internal/config"
+	"github.com/skaphos/repokeeper/internal/model"
+	"github.com/skaphos/repokeeper/internal/obs"
+	"github.com/skaphos/repokeeper/internal/registry"
+	"github.com/skaphos/repokeeper/internal/vcs"
+)
+
+// dirtyBehindAdapter reports a dirty worktree that is behind its upstream, so
+// --update-local classifies it as a "dirty working tree" skip (without
+// --rebase-dirty) or a stash+rebase candidate (with --rebase-dirty).
+type dirtyBehindAdapter struct {
+	*planAdapter
+}
+
+func (a *dirtyBehindAdapter) WorktreeStatus(context.Context, string) (*model.Worktree, error) {
+	return &model.Worktree{Dirty: true}, nil
+}
+
+func (a *dirtyBehindAdapter) TrackingStatus(context.Context, string) (model.Tracking, error) {
+	return model.Tracking{Status: model.TrackingBehind, Upstream: "origin/main"}, nil
+}
+
+func newPlanExecEngine(adapter vcs.Adapter) *Engine {
+	return &Engine{
+		cfg:        &config.Config{},
+		registry:   &registry.Registry{},
+		adapter:    adapter,
+		classifier: vcs.NewGitErrorClassifier(),
+		normalizer: vcs.NewGitURLNormalizer(),
+		logger:     obs.NopLogger(),
+	}
+}
+
+// planAndExecute mirrors the production sync flow: plan under dry-run, then apply
+// the plan through the execute path.
+func (e *Engine) planAndExecute(t *testing.T, entry registry.Entry, opts SyncOptions) (SyncResult, SyncResult) {
+	t.Helper()
+	planOpts := opts
+	planOpts.DryRun = true
+	plan := e.runSyncDryRun(context.Background(), entry, planOpts)
+	execOpts := opts
+	execOpts.DryRun = false
+	execOpts.ContinueOnError = true
+	results, err := e.ExecuteSyncPlanWithCallbacks(context.Background(), []SyncResult{plan}, execOpts, nil, nil)
+	if err != nil {
+		t.Fatalf("execute plan: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 executed result, got %d", len(results))
+	}
+	return plan, results[0]
+}
+
+// Finding 1: --update-local must not drop the fetch for skip results. A dirty
+// repo skips the local update, but the fetch still runs so remote-tracking refs
+// do not go stale relative to a plain sync.
+func TestUpdateLocalStillFetchesDirtySkip(t *testing.T) {
+	adapter := &dirtyBehindAdapter{planAdapter: &planAdapter{}}
+	eng := newPlanExecEngine(adapter)
+	entry := registry.Entry{RepoID: "repo", Path: "/repo", RemoteURL: "git@github.com:org/repo.git", Status: registry.StatusPresent}
+
+	plan, executed := eng.planAndExecute(t, entry, SyncOptions{UpdateLocal: true})
+
+	if !plan.Planned {
+		t.Fatalf("expected skip plan to be Planned so the fetch runs: %+v", plan)
+	}
+	if len(plan.steps) != 1 || plan.steps[0] != syncStepFetch {
+		t.Fatalf("expected fetch-only steps in skip plan, got %v", plan.steps)
+	}
+	if plan.SkipReason != SyncReasonDirtyWorkingTree {
+		t.Fatalf("expected dirty skip reason preserved, got %q", plan.SkipReason)
+	}
+	if len(adapter.calls) != 1 || adapter.calls[0] != "fetch:/repo" {
+		t.Fatalf("expected exactly one fetch during skipped --update-local, got %v", adapter.calls)
+	}
+	if executed.Outcome != SyncOutcomeSkippedLocalUpdate || !executed.OK {
+		t.Fatalf("expected skipped-local-update outcome preserved, got %+v", executed)
+	}
+	if executed.SkipReason != SyncReasonDirtyWorkingTree {
+		t.Fatalf("expected executed skip reason preserved, got %q", executed.SkipReason)
+	}
+}
+
+// Finding 2: an hg fetch step must actually pull. The adapter reports local
+// update unsupported (like hg) and a non-git fetch action; the execute path must
+// still route the fetch through adapter.Fetch rather than substring-matching the
+// git action text.
+func TestUpdateLocalFetchesUnsupportedBackend(t *testing.T) {
+	adapter := &unsupportedLocalUpdateAdapter{planAdapter: &planAdapter{}}
+	eng := newPlanExecEngine(adapter)
+	entry := registry.Entry{RepoID: "repo", Path: "/repo", RemoteURL: "https://hg.example/repo", Status: registry.StatusPresent}
+
+	plan, executed := eng.planAndExecute(t, entry, SyncOptions{UpdateLocal: true})
+
+	if plan.Action != "hg pull" {
+		t.Fatalf("expected hg fetch action in plan, got %q", plan.Action)
+	}
+	if !plan.Planned || len(plan.steps) != 1 || plan.steps[0] != syncStepFetch {
+		t.Fatalf("expected planned fetch step for unsupported backend, got %+v", plan)
+	}
+	if len(adapter.calls) != 1 || adapter.calls[0] != "fetch:/repo" {
+		t.Fatalf("expected fetch to run for unsupported backend, got %v", adapter.calls)
+	}
+	if executed.Outcome != SyncOutcomeSkippedLocalUpdate || !executed.OK {
+		t.Fatalf("expected skipped-local-update outcome, got %+v", executed)
+	}
+}
+
+// Finding 3: --rebase-dirty must stash in the real execute path. On a dirty repo
+// the plan must emit stash push/pop around the rebase, and executing it must run
+// the stash operations (git pull --rebase has no autostash here).
+func TestUpdateLocalRebaseDirtyStashesInExecutePath(t *testing.T) {
+	adapter := &dirtyBehindAdapter{planAdapter: &planAdapter{stashCreated: true}}
+	eng := newPlanExecEngine(adapter)
+	entry := registry.Entry{RepoID: "repo", Path: "/repo", RemoteURL: "git@github.com:org/repo.git", Status: registry.StatusPresent}
+
+	plan, executed := eng.planAndExecute(t, entry, SyncOptions{UpdateLocal: true, RebaseDirty: true})
+
+	wantSteps := []syncStep{syncStepFetch, syncStepStashPush, syncStepPullRebase, syncStepStashPop}
+	if len(plan.steps) != len(wantSteps) {
+		t.Fatalf("expected stash steps planned, got %v", plan.steps)
+	}
+	for i, s := range wantSteps {
+		if plan.steps[i] != s {
+			t.Fatalf("unexpected plan step %d: got %q want %q (all: %v)", i, plan.steps[i], s, plan.steps)
+		}
+	}
+	wantCalls := []string{"fetch:/repo", "stash-push:/repo", "pull:/repo", "stash-pop:/repo"}
+	if len(adapter.calls) != len(wantCalls) {
+		t.Fatalf("expected stash+rebase call sequence, got %v", adapter.calls)
+	}
+	for i, c := range wantCalls {
+		if adapter.calls[i] != c {
+			t.Fatalf("unexpected call %d: got %q want %q (all: %v)", i, adapter.calls[i], c, adapter.calls)
+		}
+	}
+	if executed.Outcome != SyncOutcomeStashedRebased || !executed.OK {
+		t.Fatalf("expected stashed_rebased outcome, got %+v", executed)
+	}
+}
+
+// Finding 5: ApplyRemoteMismatchPlans must use the engine's injected adapter, not
+// a hardcoded git adapter, so custom/test adapters and --vcs git,hg are honored.
+func TestApplyRemoteMismatchPlansUsesInjectedAdapter(t *testing.T) {
+	adapter := &planAdapter{}
+	eng := newPlanExecEngine(adapter)
+
+	plans := []RemoteMismatchPlan{{
+		RepoID:        "repo",
+		Path:          "/repo",
+		PrimaryRemote: "origin",
+		RegistryURL:   "git@github.com:org/repo.git",
+		EntryIndex:    0,
+	}}
+	if err := eng.ApplyRemoteMismatchPlans(context.Background(), plans, RemoteMismatchReconcileGit); err != nil {
+		t.Fatalf("apply remote mismatch plans: %v", err)
+	}
+	want := "set-remote-url:/repo:origin:git@github.com:org/repo.git"
+	if len(adapter.calls) != 1 || adapter.calls[0] != want {
+		t.Fatalf("expected injected adapter to receive set-remote-url, got %v", adapter.calls)
+	}
+}
+
+// Finding 7: ParseFilterKind validates filter values, defaulting empty to
+// FilterAll and rejecting unknown values.
+func TestParseFilterKind(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    FilterKind
+		wantErr bool
+	}{
+		{raw: "", want: FilterAll},
+		{raw: "  ", want: FilterAll},
+		{raw: "dirty", want: FilterDirty},
+		{raw: "REMOTE-MISMATCH", want: FilterRemoteMismatch},
+		{raw: "garbage", wantErr: true},
+		{raw: "dir", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := ParseFilterKind(tc.raw)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("ParseFilterKind(%q): expected error, got %q", tc.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("ParseFilterKind(%q): unexpected error %v", tc.raw, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseFilterKind(%q): got %q want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+// Finding 7 (defense-in-depth): an unknown filter must fail closed in the sync
+// path so it matches nothing rather than every repository.
+func TestPrepareSyncEntryUnknownFilterFailsClosed(t *testing.T) {
+	eng := newPlanExecEngine(&planAdapter{})
+	present := registry.Entry{RepoID: "repo", Path: "/repo", RemoteURL: "git@github.com:org/repo.git", Status: registry.StatusPresent}
+
+	queue, immediate := eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterKind("bogus")}, 0)
+	if queue || immediate != nil {
+		t.Fatalf("expected unknown filter to fail closed (no queue, no result), got queue=%v immediate=%v", queue, immediate)
+	}
+
+	// A known non-inspect filter (all) still matches.
+	queue, immediate = eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterAll}, 0)
+	if !queue || immediate != nil {
+		t.Fatalf("expected FilterAll to queue the entry, got queue=%v immediate=%v", queue, immediate)
+	}
+}

--- a/internal/engine/remotemismatch.go
+++ b/internal/engine/remotemismatch.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/remotemismatch"
-	"github.com/skaphos/repokeeper/internal/vcs"
 )
 
 // RemoteMismatchReconcileMode controls how remote mismatch reconciliation is applied.
@@ -37,5 +36,5 @@ func (e *Engine) BuildRemoteMismatchPlans(repos []model.RepoStatus, mode RemoteM
 
 // ApplyRemoteMismatchPlans applies reconcile plans to registry and/or git remotes.
 func (e *Engine) ApplyRemoteMismatchPlans(ctx context.Context, plans []RemoteMismatchPlan, mode RemoteMismatchReconcileMode) error {
-	return remotemismatch.ApplyPlans(ctx, plans, e.registry, mode, vcs.NewGitAdapter(nil), nil)
+	return remotemismatch.ApplyPlans(ctx, plans, e.registry, mode, e.adapter, nil)
 }


### PR DESCRIPTION
## Summary

Resolves verified code-review findings in the sync/apply path. The root cause behind several bugs was that the sync **plan executor dispatched by substring-matching the human-readable `Action` string**. This PR replaces that with **typed plan steps** (`syncStep`) that route through the VCS adapter, and fixes the surrounding filter/adapter correctness issues. All changes are confined to `internal/engine/`.

Production flow is: `Sync(DryRun:true)` builds a plan → `ExecuteSyncPlanWithCallbacks(DryRun:false)` applies it. The planner now emits an ordered `steps []syncStep` on each planned result; the executor iterates those steps.

## Findings fixed

| # | Sev | Fix | Files |
|---|-----|-----|-------|
| 1 | P0 | `--update-local` dropped the fetch for skip results (dirty/up-to-date/detached/protected/diverged/unsupported). `runSyncDryRun` now emits a **Planned fetch step** for skip-local-update repos, so the fetch always runs while the typed skip reason is preserved. | `engine.go` |
| 2 | P1 | hg fetch was silently no-opped (substring match on `git fetch --all`). Execution now dispatches on typed steps and routes fetch through `e.adapter.Fetch`, so hg (`hg pull`) works. | `engine.go` |
| 3 | P1 | `--rebase-dirty` never stashed in the real execute path. The planner emits `stash push`/`stash pop` steps around `pull --rebase` when the worktree is dirty; the executor performs them. | `engine.go` |
| 4 | P1 | `CloneAndRegister` recorded no `RemoteURL`, making fresh clones invisible to sync / breaking `--checkout-missing`. Now sets `entry.RemoteURL`. | `actions.go` |
| 5 | P2 | `ApplyRemoteMismatchPlans` hardcoded `vcs.NewGitAdapter(nil)`; now uses the engine's injected `e.adapter`. | `remotemismatch.go` |
| 6 | P2 | clean-filter divergence: `syncEntryMatchesInspectFilter` treated a bare repo as clean while `filterStatus` did not. Aligned to `filterStatus` (no worktree ⇒ not clean). | `engine.go` |
| 7 | defense | Unknown `FilterKind` failed open (matched everything). Both filter paths now **fail closed**; added exported `ParseFilterKind`. Empty filter still means "all". | `engine.go` |
| 8 | dead code | See below. | `engine.go` |

## Finding 8 — removed vs. wired vs. deferred

**Removed** (production-unreachable, confirmed by grep; tests migrated):
- `SyncOutcome` type alias.
- `ExecuteSyncPlan` and `ExecuteSyncPlanWithCallback` wrappers — production uses `ExecuteSyncPlanWithCallbacks`. Engine tests updated to call it directly.

**Wired** (correct behavior moved into the production plan/execute path):
- Fetch-on-skip (finding 1), adapter-routed fetch (finding 2), and pre-rebase stash (finding 3) now live in the typed-step planner/executor — previously these were only correct in the live `runSyncApply`/`runSyncRebaseApply` path, which production never calls.

**Deferred, with rationale** (`runSyncApply` @ engine.go, `runSyncRebaseApply`, and the `handleMissingSyncEntry` live-clone branch):
- These are unreachable from the app's own entry points (all call `Sync(DryRun:true)` then `ExecuteSyncPlanWithCallbacks`), **but** they remain reachable via the public `Sync(DryRun:false)` API and back ~18 direct-apply specs (`engine_test.go`, `integration_test.go`) that exercise real fetch/stash/rebase/timeout/concurrency behavior. Deleting them requires migrating that whole suite to the plan/execute flow and changing `Sync`'s contract — a larger refactor than these findings warrant. The user-facing bugs are already fixed in the production path; consolidating onto a single execution path is flagged as a follow-up. Per the review guidance I chose the conservative option rather than guessing on that refactor.

## Tests
- New `engine_sync_planexec_internal_test.go` drives the plan-then-execute flow:
  - `TestUpdateLocalStillFetchesDirtySkip` (finding 1) — dirty repo under `--update-local` still fetches; skip reason preserved.
  - `TestUpdateLocalFetchesUnsupportedBackend` (finding 2) — hg-like adapter's fetch actually runs through the execute path.
  - `TestUpdateLocalRebaseDirtyStashesInExecutePath` (finding 3) — asserts `fetch → stash-push → pull → stash-pop` call sequence and `stashed_rebased`.
  - `TestApplyRemoteMismatchPlansUsesInjectedAdapter` (finding 5).
  - `TestParseFilterKind` + `TestPrepareSyncEntryUnknownFilterFailsClosed` (finding 7).
- Extended the existing `CloneAndRegister` test to assert `RemoteURL` (finding 4).
- Updated executor/filter unit tests for typed-step dispatch and fail-closed filters.

## Verification (all pass)
- `go build ./...`
- `go vet ./internal/engine/...`
- `staticcheck ./internal/engine/...` (v0.7.0)
- `go test ./internal/engine/...` and `go test ./...`
- `go test -race` on the sync/executor/new tests — clean.

### Reviewer note (pre-existing, out of scope)
`go test -race` on the **Status** Ginkgo spec reports a data race in `registry.backfillCheckoutID` (`internal/registry/registry.go`), reached via the concurrent status-worker path. I confirmed this race reproduces on clean `origin/main` and it is unrelated to these findings; it lives outside the `internal/engine` scope of this PR. Not fixed here — worth a separate issue (the lazy checkout-ID backfill mutates shared registry entries without locking).