### PR TITLE
fix(tui): program-reference race, unsynchronized registry writes, ghost rows, and 6 other TUI findings

### DIFF
--- a/internal/tui/actions_internal_test.go
+++ b/internal/tui/actions_internal_test.go
@@ -115,6 +115,9 @@ func TestHandleLabelEditSavePersistsConfig(t *testing.T) {
 	if nm.mode != viewDetail || nm.statusMsg != "updated labels for acme/a" || refresh == nil {
 		t.Fatalf("unexpected post-save state: %+v", nm)
 	}
+	if !nm.loading || nm.pendingInspections != 1 {
+		t.Fatalf("expected loading=true and pendingInspections=1 for the refresh stream, got loading=%v pendingInspections=%d", nm.loading, nm.pendingInspections)
+	}
 	loaded, err := config.Load(cfgPath)
 	if err != nil {
 		t.Fatalf("reload config: %v", err)
@@ -172,6 +175,9 @@ func TestHandleRepoMetadataEditSaveWritesRepoMetadata(t *testing.T) {
 	nm := next.(tuiModel)
 	if nm.mode != viewDetail || nm.statusMsg != "updated repo metadata for acme/a" || refresh == nil {
 		t.Fatalf("unexpected post-save state: %+v", nm)
+	}
+	if !nm.loading || nm.pendingInspections != 1 {
+		t.Fatalf("expected loading=true and pendingInspections=1 for the refresh stream, got loading=%v pendingInspections=%d", nm.loading, nm.pendingInspections)
 	}
 	_, metadata, err := repometa.Load(repoPath)
 	if err != nil {
@@ -522,6 +528,29 @@ func TestHandleDeleteConfirmKey(t *testing.T) {
 	}
 }
 
+func TestHandleDeleteConfirmKeyResetsOffset(t *testing.T) {
+	t.Parallel()
+
+	for _, modalCursor := range []int{1, 2} {
+		m := tuiModel{
+			mode:         viewDeleteConfirm,
+			deleteRepoID: "acme/a",
+			modalCursor:  modalCursor,
+			cursor:       9,
+			offset:       8,
+			engine:       &mockEngine{},
+		}
+		next, cmd := m.handleDeleteConfirmKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+		if cmd == nil {
+			t.Fatalf("expected delete command for modalCursor=%d", modalCursor)
+		}
+		nm := next.(tuiModel)
+		if nm.cursor != 0 || nm.offset != 0 {
+			t.Fatalf("expected cursor and offset reset to 0 for modalCursor=%d, got cursor=%d offset=%d", modalCursor, nm.cursor, nm.offset)
+		}
+	}
+}
+
 func TestHandleRepairConfirmKey(t *testing.T) {
 	t.Parallel()
 
@@ -867,6 +896,43 @@ func TestHelpersAndPathResolution(t *testing.T) {
 	}
 }
 
+func TestActionCmdsPropagateProvidedContext(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	eng := &mockEngine{}
+
+	if _, ok := deleteRepoCmd(ctx, eng, "acme/a", "/tmp/cfg.yaml", false)().(deleteDoneMsg); !ok {
+		t.Fatal("expected deleteDoneMsg")
+	}
+	if eng.lastDeleteCtx != ctx {
+		t.Fatal("expected deleteRepoCmd to call DeleteRepo with the provided context, not context.Background()")
+	}
+
+	if _, ok := resetRepoCmd(ctx, eng, "acme/a", "/tmp/cfg.yaml")().(resetDoneMsg); !ok {
+		t.Fatal("expected resetDoneMsg")
+	}
+	if eng.lastResetCtx != ctx {
+		t.Fatal("expected resetRepoCmd to call ResetRepo with the provided context, not context.Background()")
+	}
+
+	if _, ok := repairUpstreamCmd(ctx, eng, "acme/a", "/tmp/cfg.yaml")().(repairDoneMsg); !ok {
+		t.Fatal("expected repairDoneMsg")
+	}
+	if eng.lastRepairCtx != ctx {
+		t.Fatal("expected repairUpstreamCmd to call RepairUpstream with the provided context, not context.Background()")
+	}
+
+	if _, ok := cloneAndRegisterCmd(ctx, eng, "https://example.com/acme/a.git", "/tmp/a", "/tmp/cfg.yaml", false)().(addDoneMsg); !ok {
+		t.Fatal("expected addDoneMsg")
+	}
+	if eng.lastCloneCtx != ctx {
+		t.Fatal("expected cloneAndRegisterCmd to call CloneAndRegister with the provided context, not context.Background()")
+	}
+}
+
 func TestResolveRepairTarget(t *testing.T) {
 	t.Parallel()
 
@@ -900,6 +966,132 @@ func TestResolveRepairTarget(t *testing.T) {
 	}
 }
 
+func TestResolveRepairTargetUsesPathForDuplicateRepoID(t *testing.T) {
+	t.Parallel()
+
+	// Two checkouts share the same repo_id (e.g. hand-edited registry.yaml
+	// or a stale duplicate). Resolving by repo_id alone (first match) would
+	// use the wrong entry's branch; resolving by the selected row's path
+	// must use the checkout actually under the cursor.
+	reg := &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "acme/backend", Path: "/work/primary", Branch: "main", Status: registry.StatusPresent},
+		{RepoID: "acme/backend", Path: "/work/secondary", Branch: "feature", Status: registry.StatusPresent},
+	}}
+	eng := &mockEngine{reg: reg}
+	repos := []model.RepoStatus{{
+		RepoID: "acme/backend", Path: "/work/secondary", PrimaryRemote: "origin", Head: model.Head{Branch: "feature"},
+	}}
+
+	repoID, target, err := resolveRepairTarget(tuiModel{engine: eng, repos: repos, cursor: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repoID != "acme/backend" || target != "origin/feature" {
+		t.Fatalf("expected target derived from the secondary checkout's own branch, got repoID=%q target=%q", repoID, target)
+	}
+}
+
+func TestPrepareEditCmdResolvesRowByPathWhenRepoIDDuplicated(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("EDITOR", "true")
+	t.Setenv("VISUAL", "")
+
+	reg := &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "acme/backend", Path: "/work/primary", Branch: "main", Status: registry.StatusPresent},
+		{RepoID: "acme/backend", Path: "/work/secondary", Branch: "feature", Status: registry.StatusPresent},
+	}}
+	eng := &mockEngine{reg: reg}
+	repos := []model.RepoStatus{
+		{RepoID: "acme/backend", Path: "/work/primary"},
+		{RepoID: "acme/backend", Path: "/work/secondary"},
+	}
+	m := tuiModel{repos: repos, cursor: 1, engine: eng}
+
+	cmd := prepareEditCmd(m)
+	if cmd == nil {
+		t.Fatal("expected prepare edit cmd")
+	}
+	msg, ok := cmd().(editReadyMsg)
+	if !ok {
+		t.Fatalf("expected editReadyMsg, got %T", cmd())
+	}
+	defer os.Remove(msg.tmpPath)
+	if msg.originalEntry.Path != "/work/secondary" || msg.originalEntry.Branch != "feature" {
+		t.Fatalf("expected edit to target the row under the cursor (secondary checkout), got %+v", msg.originalEntry)
+	}
+}
+
+func TestStartDeleteBlocksAmbiguousRepoID(t *testing.T) {
+	t.Parallel()
+
+	reg := &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "acme/backend", Path: "/work/primary", Status: registry.StatusPresent},
+		{RepoID: "acme/backend", Path: "/work/secondary", Status: registry.StatusPresent},
+	}}
+	eng := &mockEngine{reg: reg}
+	repos := []model.RepoStatus{
+		{RepoID: "acme/backend", Path: "/work/primary"},
+		{RepoID: "acme/backend", Path: "/work/secondary"},
+	}
+	m := tuiModel{repos: repos, cursor: 1, engine: eng}
+
+	next, cmd := m.startDelete()
+	nm := next.(tuiModel)
+	if nm.mode == viewDeleteConfirm || cmd != nil {
+		t.Fatalf("expected ambiguous repo_id to block delete, got mode=%v cmd=%v", nm.mode, cmd)
+	}
+	if !nm.statusIsError || !strings.Contains(nm.statusMsg, "ambiguous") {
+		t.Fatalf("expected ambiguous status message, got %+v", nm)
+	}
+}
+
+func TestStartResetBlocksAmbiguousRepoID(t *testing.T) {
+	t.Parallel()
+
+	reg := &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "acme/backend", Path: "/work/primary", Status: registry.StatusPresent},
+		{RepoID: "acme/backend", Path: "/work/secondary", Status: registry.StatusPresent},
+	}}
+	eng := &mockEngine{reg: reg}
+	repos := []model.RepoStatus{
+		{RepoID: "acme/backend", Path: "/work/primary"},
+		{RepoID: "acme/backend", Path: "/work/secondary"},
+	}
+	m := tuiModel{repos: repos, cursor: 1, engine: eng}
+
+	next, cmd := m.startReset()
+	nm := next.(tuiModel)
+	if nm.mode == viewResetConfirm || cmd != nil {
+		t.Fatalf("expected ambiguous repo_id to block reset, got mode=%v cmd=%v", nm.mode, cmd)
+	}
+	if !nm.statusIsError || !strings.Contains(nm.statusMsg, "ambiguous") {
+		t.Fatalf("expected ambiguous status message, got %+v", nm)
+	}
+}
+
+func TestStartRepairBlocksAmbiguousRepoID(t *testing.T) {
+	t.Parallel()
+
+	reg := &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "acme/backend", Path: "/work/primary", Branch: "main", Status: registry.StatusPresent},
+		{RepoID: "acme/backend", Path: "/work/secondary", Branch: "feature", Status: registry.StatusPresent},
+	}}
+	eng := &mockEngine{reg: reg}
+	repos := []model.RepoStatus{{
+		RepoID: "acme/backend", Path: "/work/secondary", PrimaryRemote: "origin", Head: model.Head{Branch: "feature"},
+	}}
+	m := tuiModel{repos: repos, cursor: 0, engine: eng}
+
+	next, cmd := m.startRepair()
+	nm := next.(tuiModel)
+	if nm.mode == viewRepairConfirm || cmd != nil {
+		t.Fatalf("expected ambiguous repo_id to block repair, got mode=%v cmd=%v", nm.mode, cmd)
+	}
+	if !nm.statusIsError || !strings.Contains(nm.statusMsg, "ambiguous") {
+		t.Fatalf("expected ambiguous status message, got %+v", nm)
+	}
+}
+
 func TestModalHelpers(t *testing.T) {
 	t.Parallel()
 
@@ -923,7 +1115,7 @@ func TestModalHelpers(t *testing.T) {
 	}
 
 	m := tuiModel{modalCursor: 0}
-	m = modalMoveLeft(m, 2)
+	m = modalMoveLeft(m)
 	if m.modalCursor != 0 {
 		t.Fatal("expected left clamp at 0")
 	}
@@ -1122,6 +1314,74 @@ func TestTUIUsesSharedAndLocalLabelsDistinctly(t *testing.T) {
 	}
 	if !strings.Contains(detail, "    role=service") {
 		t.Fatalf("expected shared label in repo metadata section, got %q", detail)
+	}
+}
+
+func TestSanitizeMetadataText(t *testing.T) {
+	t.Parallel()
+
+	if got := sanitizeMetadataText("plain text"); got != "plain text" {
+		t.Fatalf("expected unchanged plain text, got %q", got)
+	}
+	if got := sanitizeMetadataText("a\x1b[31mb\x07c\nd"); got != "abcd" {
+		t.Fatalf("expected control/escape characters stripped, got %q", got)
+	}
+	if got := sanitizeMetadataText(""); got != "" {
+		t.Fatalf("expected empty string unchanged, got %q", got)
+	}
+}
+
+func TestRenderDetailViewStripsControlCharactersFromRepoMetadata(t *testing.T) {
+	t.Parallel()
+
+	// RepoMetadata is loaded from a file inside the cloned repository
+	// (.repokeeper-repo.yaml), so a hostile or compromised upstream fully
+	// controls these strings. Rendering them raw would let it smuggle
+	// terminal escape sequences into the operator's terminal.
+	const escSeq = "\x1b[31mHACKED\x1b[0m"
+	repo := model.RepoStatus{
+		RepoID: "acme/backend",
+		Path:   "/work/backend",
+		RepoMetadata: &model.RepoMetadata{
+			Name:        escSeq,
+			RepoID:      "acme\x1b]0;pwned\x07/backend",
+			Labels:      map[string]string{"team": escSeq},
+			Entrypoints: map[string]string{"readme": "README.md" + escSeq},
+			Paths:       model.RepoMetadataPaths{Authoritative: []string{"docs" + escSeq}},
+			Provides:    []string{escSeq},
+			RelatedRepos: []model.RepoMetadataRelatedRepo{
+				{RepoID: escSeq, Relationship: escSeq},
+			},
+		},
+		RepoMetadataError: "repo metadata repo_id " + escSeq + " mismatch",
+	}
+
+	detail := renderDetailView(tuiModel{width: 100, repos: []model.RepoStatus{repo}, cursor: 0})
+
+	// Isolate the repo-metadata-derived body: the surrounding title/header/
+	// footer lines are legitimately styled by the app itself (lipgloss), so
+	// they contain their own, harmless ANSI codes. Only the bytes that came
+	// from RepoMetadata must be free of escape sequences. The metadata
+	// block ends at the blank line separating it from the next section
+	// (Last Sync, if any, or the footer).
+	start := strings.Index(detail, "Name:")
+	if start == -1 {
+		t.Fatalf("expected to locate the repo metadata body, got %q", detail)
+	}
+	blank := strings.Index(detail[start:], "\n\n")
+	if blank == -1 {
+		t.Fatalf("expected a blank line ending the repo metadata body, got %q", detail)
+	}
+	metadataBody := detail[start : start+blank]
+
+	if strings.ContainsAny(metadataBody, "\x1b\x07") {
+		t.Fatalf("expected injected escape/control bytes to be stripped from repo metadata, got %q", metadataBody)
+	}
+	if !strings.Contains(metadataBody, "HACKED") {
+		t.Fatalf("expected sanitized text content to remain, got %q", metadataBody)
+	}
+	if !strings.Contains(metadataBody, "Repo ID: acme/backend") {
+		t.Fatalf("expected the OSC-injected repo ID to sanitize down to the plain text, got %q", metadataBody)
 	}
 }
 

--- a/internal/tui/actions_internal_test.go
+++ b/internal/tui/actions_internal_test.go
@@ -1329,6 +1329,22 @@ func TestSanitizeMetadataText(t *testing.T) {
 	if got := sanitizeMetadataText(""); got != "" {
 		t.Fatalf("expected empty string unchanged, got %q", got)
 	}
+	// UTF-8-encoded C1 controls (0xC2 0x80..0x9F): a single-byte CSI (U+009B) or
+	// OSC (U+009D) introducer, and a bare C1 control, must all be stripped along
+	// with any sequence they introduce.
+	if got := sanitizeMetadataText("a\u009b31mb"); got != "ab" {
+		t.Fatalf("expected C1 CSI sequence stripped, got %q", got)
+	}
+	if got := sanitizeMetadataText("a\u009d0;title\u009cb"); got != "ab" {
+		t.Fatalf("expected C1 OSC sequence stripped, got %q", got)
+	}
+	if got := sanitizeMetadataText("a\u0085b"); got != "ab" {
+		t.Fatalf("expected bare C1 control stripped, got %q", got)
+	}
+	// A legitimate two-byte UTF-8 rune that is not a C1 control must survive.
+	if got := sanitizeMetadataText("café"); got != "café" {
+		t.Fatalf("expected non-C1 multibyte rune preserved, got %q", got)
+	}
 }
 
 func TestRenderDetailViewStripsControlCharactersFromRepoMetadata(t *testing.T) {

--- a/internal/tui/actions_internal_test.go
+++ b/internal/tui/actions_internal_test.go
@@ -1015,7 +1015,7 @@ func TestPrepareEditCmdResolvesRowByPathWhenRepoIDDuplicated(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected editReadyMsg, got %T", cmd())
 	}
-	defer os.Remove(msg.tmpPath)
+	defer func() { _ = os.Remove(msg.tmpPath) }()
 	if msg.originalEntry.Path != "/work/secondary" || msg.originalEntry.Branch != "feature" {
 		t.Fatalf("expected edit to target the row under the cursor (secondary checkout), got %+v", msg.originalEntry)
 	}

--- a/internal/tui/add_action.go
+++ b/internal/tui/add_action.go
@@ -21,9 +21,9 @@ type addDoneMsg struct {
 	err    error
 }
 
-func cloneAndRegisterCmd(eng EngineAPI, url, path, cfgPath string, mirror bool) tea.Cmd {
+func cloneAndRegisterCmd(ctx context.Context, eng EngineAPI, url, path, cfgPath string, mirror bool) tea.Cmd {
 	return func() tea.Msg {
-		err := eng.CloneAndRegister(context.Background(), url, path, cfgPath, mirror)
+		err := eng.CloneAndRegister(ctx, url, path, cfgPath, mirror)
 		if err != nil {
 			return addDoneMsg{repoID: repoNameFromURL(url), err: err}
 		}

--- a/internal/tui/delete_action.go
+++ b/internal/tui/delete_action.go
@@ -14,9 +14,9 @@ type deleteDoneMsg struct {
 	err    error
 }
 
-func deleteRepoCmd(eng EngineAPI, repoID, cfgPath string, deleteFiles bool) tea.Cmd {
+func deleteRepoCmd(ctx context.Context, eng EngineAPI, repoID, cfgPath string, deleteFiles bool) tea.Cmd {
 	return func() tea.Msg {
-		err := eng.DeleteRepo(context.Background(), repoID, cfgPath, deleteFiles)
+		err := eng.DeleteRepo(ctx, repoID, cfgPath, deleteFiles)
 		return deleteDoneMsg{repoID: repoID, err: err}
 	}
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -147,6 +147,12 @@ func renderDetailView(m tuiModel) string {
 // is not enough: everything after the leading ESC byte in an escape
 // sequence (e.g. "[31m") is ordinary printable text, so the sequence's
 // effect survives unless the whole thing is dropped.
+//
+// This also covers the C1 controls (U+0080..U+009F). In UTF-8 those encode as
+// 0xC2 followed by 0x80..0x9F, whose bytes are both >= 0x20 and so would
+// otherwise pass straight through — yet many terminals honor them as control
+// codes (U+009B is a single-byte CSI introducer, U+009D an OSC introducer), so
+// they are just as dangerous as their ESC-prefixed C0 equivalents.
 func sanitizeMetadataText(s string) string {
 	if s == "" {
 		return s
@@ -159,6 +165,10 @@ func sanitizeMetadataText(s string) string {
 		switch {
 		case c == 0x1b: // ESC: drop the entire escape sequence
 			i = skipEscapeSequence(src, i)
+		case c == 0xc2 && i+1 < len(src) && src[i+1] >= 0x80 && src[i+1] <= 0x9f:
+			// UTF-8-encoded C1 control: drop it, and for the CSI/OSC introducers
+			// the whole sequence they start.
+			i = skipC1Sequence(src, i)
 		case c < 0x20 || c == 0x7f: // bare C0 control byte / DEL
 			continue
 		default:
@@ -166,6 +176,43 @@ func sanitizeMetadataText(s string) string {
 		}
 	}
 	return out.String()
+}
+
+// skipC1Sequence returns the index of the last byte belonging to a UTF-8
+// encoded C1 control that starts at src[start] (0xC2, with the C1 byte at
+// start+1). U+009B (CSI) and U+009D (OSC) introduce full control sequences,
+// handled like their ESC '[' / ESC ']' equivalents (OSC may be terminated by a
+// C1 ST, U+009C, as well as BEL or ESC '\'); any other C1 control is just the
+// two-byte encoding itself.
+func skipC1Sequence(src []byte, start int) int {
+	switch src[start+1] {
+	case 0x9b: // CSI
+		j := start + 2
+		for j < len(src) && src[j] >= 0x20 && src[j] <= 0x3f {
+			j++
+		}
+		if j < len(src) {
+			return j
+		}
+		return j - 1
+	case 0x9d: // OSC
+		j := start + 2
+		for j < len(src) {
+			if src[j] == 0x07 {
+				return j
+			}
+			if src[j] == 0x1b && j+1 < len(src) && src[j+1] == '\\' {
+				return j + 1
+			}
+			if src[j] == 0xc2 && j+1 < len(src) && src[j+1] == 0x9c { // C1 ST
+				return j + 1
+			}
+			j++
+		}
+		return j - 1
+	default:
+		return start + 1
+	}
 }
 
 // skipEscapeSequence returns the index of the last byte belonging to the

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -73,47 +73,49 @@ func renderDetailView(m tuiModel) string {
 		}
 		if r.RepoMetadata != nil {
 			if r.RepoMetadata.Name != "" {
-				fmt.Fprintf(&b, "  Name: %s\n", r.RepoMetadata.Name)
+				fmt.Fprintf(&b, "  Name: %s\n", sanitizeMetadataText(r.RepoMetadata.Name))
 			}
 			if r.RepoMetadata.RepoID != "" {
-				fmt.Fprintf(&b, "  Repo ID: %s\n", r.RepoMetadata.RepoID)
+				fmt.Fprintf(&b, "  Repo ID: %s\n", sanitizeMetadataText(r.RepoMetadata.RepoID))
 			}
 			if len(r.RepoMetadata.Labels) > 0 {
 				b.WriteString("  Shared Labels:\n")
 				for _, k := range sortedKeys(r.RepoMetadata.Labels) {
 					v := r.RepoMetadata.Labels[k]
-					fmt.Fprintf(&b, "    %s=%s\n", k, v)
+					fmt.Fprintf(&b, "    %s=%s\n", sanitizeMetadataText(k), sanitizeMetadataText(v))
 				}
 			}
 			if len(r.RepoMetadata.Entrypoints) > 0 {
 				b.WriteString("  Entrypoints:\n")
 				for _, k := range sortedKeys(r.RepoMetadata.Entrypoints) {
 					v := r.RepoMetadata.Entrypoints[k]
-					fmt.Fprintf(&b, "    %s=%s\n", k, v)
+					fmt.Fprintf(&b, "    %s=%s\n", sanitizeMetadataText(k), sanitizeMetadataText(v))
 				}
 			}
 			if len(r.RepoMetadata.Paths.Authoritative) > 0 {
-				fmt.Fprintf(&b, "  Authoritative: %s\n", strings.Join(r.RepoMetadata.Paths.Authoritative, ", "))
+				fmt.Fprintf(&b, "  Authoritative: %s\n", strings.Join(sanitizeMetadataSlice(r.RepoMetadata.Paths.Authoritative), ", "))
 			}
 			if len(r.RepoMetadata.Paths.LowValue) > 0 {
-				fmt.Fprintf(&b, "  Low value: %s\n", strings.Join(r.RepoMetadata.Paths.LowValue, ", "))
+				fmt.Fprintf(&b, "  Low value: %s\n", strings.Join(sanitizeMetadataSlice(r.RepoMetadata.Paths.LowValue), ", "))
 			}
 			if len(r.RepoMetadata.Provides) > 0 {
-				fmt.Fprintf(&b, "  Provides: %s\n", strings.Join(r.RepoMetadata.Provides, ", "))
+				fmt.Fprintf(&b, "  Provides: %s\n", strings.Join(sanitizeMetadataSlice(r.RepoMetadata.Provides), ", "))
 			}
 			if len(r.RepoMetadata.RelatedRepos) > 0 {
 				b.WriteString("  Related repos:\n")
 				for _, related := range r.RepoMetadata.RelatedRepos {
-					if related.Relationship == "" {
-						fmt.Fprintf(&b, "    %s\n", related.RepoID)
+					repoID := sanitizeMetadataText(related.RepoID)
+					relationship := sanitizeMetadataText(related.Relationship)
+					if relationship == "" {
+						fmt.Fprintf(&b, "    %s\n", repoID)
 						continue
 					}
-					fmt.Fprintf(&b, "    %s (%s)\n", related.RepoID, related.Relationship)
+					fmt.Fprintf(&b, "    %s (%s)\n", repoID, relationship)
 				}
 			}
 		}
 		if r.RepoMetadataError != "" {
-			fmt.Fprintf(&b, "  Error: %s\n", r.RepoMetadataError)
+			fmt.Fprintf(&b, "  Error: %s\n", sanitizeMetadataText(r.RepoMetadataError))
 		}
 		b.WriteByte('\n')
 	}
@@ -134,6 +136,81 @@ func renderDetailView(m tuiModel) string {
 
 	b.WriteString(statusBarStyle.Render("esc/q: back  l: edit labels  i: repo metadata"))
 	return b.String()
+}
+
+// sanitizeMetadataText strips control characters and whole ANSI/terminal
+// escape sequences from repo-controlled metadata before it is written to
+// the terminal. RepoMetadata is loaded from a file inside the cloned
+// repository (repometa.Load), so a hostile or compromised upstream could
+// otherwise smuggle escape sequences into the operator's terminal via Name,
+// labels, entrypoints, and similar fields. Bare stripping of control runes
+// is not enough: everything after the leading ESC byte in an escape
+// sequence (e.g. "[31m") is ordinary printable text, so the sequence's
+// effect survives unless the whole thing is dropped.
+func sanitizeMetadataText(s string) string {
+	if s == "" {
+		return s
+	}
+	src := []byte(s)
+	var out strings.Builder
+	out.Grow(len(src))
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch {
+		case c == 0x1b: // ESC: drop the entire escape sequence
+			i = skipEscapeSequence(src, i)
+		case c < 0x20 || c == 0x7f: // bare C0 control byte / DEL
+			continue
+		default:
+			out.WriteByte(c)
+		}
+	}
+	return out.String()
+}
+
+// skipEscapeSequence returns the index of the last byte belonging to the
+// escape sequence that starts with ESC at src[start], so the caller can
+// resume scanning right after it. It recognizes CSI sequences (ESC '['
+// parameter/intermediate bytes, final byte) and OSC sequences (ESC ']' ...
+// terminated by BEL or ESC '\'); any other byte following ESC is treated as
+// a minimal two-byte sequence.
+func skipEscapeSequence(src []byte, start int) int {
+	if start+1 >= len(src) {
+		return start
+	}
+	switch src[start+1] {
+	case '[':
+		j := start + 2
+		for j < len(src) && src[j] >= 0x20 && src[j] <= 0x3f {
+			j++
+		}
+		if j < len(src) {
+			return j
+		}
+		return j - 1
+	case ']':
+		j := start + 2
+		for j < len(src) {
+			if src[j] == 0x07 {
+				return j
+			}
+			if src[j] == 0x1b && j+1 < len(src) && src[j+1] == '\\' {
+				return j + 1
+			}
+			j++
+		}
+		return j - 1
+	default:
+		return start + 1
+	}
+}
+
+func sanitizeMetadataSlice(values []string) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = sanitizeMetadataText(v)
+	}
+	return out
 }
 
 func sortedKeys(values map[string]string) []string {

--- a/internal/tui/edit_action.go
+++ b/internal/tui/edit_action.go
@@ -49,18 +49,11 @@ func prepareEditCmd(m tuiModel) tea.Cmd {
 			return editDoneMsg{err: fmt.Errorf("registry not available")}
 		}
 
-		var entry registry.Entry
-		entryIdx := -1
-		for i, e := range reg.Entries {
-			if e.RepoID == repo.RepoID {
-				entry = e
-				entryIdx = i
-				break
-			}
-		}
+		entryIdx := registryEntryIndexByIdentity(reg, repo.RepoID, repo.Path)
 		if entryIdx < 0 {
 			return editDoneMsg{err: fmt.Errorf("registry entry not found for %s", repo.RepoID)}
 		}
+		entry := reg.Entries[entryIdx]
 
 		editorParts, err := editor.ResolveEditorCommand()
 		if err != nil {

--- a/internal/tui/identity.go
+++ b/internal/tui/identity.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/skaphos/repokeeper/internal/engine"
 	"github.com/skaphos/repokeeper/internal/model"
+	"github.com/skaphos/repokeeper/internal/registry"
 )
 
 const checkoutIdentitySeparator = "\x00"
@@ -52,6 +53,24 @@ func findRepoStatusIndex(rows []model.RepoStatus, incoming model.RepoStatus) int
 	}
 
 	return -1
+}
+
+// repoIDRowCount returns how many registry entries share repoID. EngineAPI's
+// delete/reset/repair operations are addressed by repo_id alone, so when
+// this is more than one, repo_id cannot safely select a single checkout for
+// those calls and the caller must refuse rather than risk acting on the
+// wrong one.
+func repoIDRowCount(reg *registry.Registry, repoID string) int {
+	if reg == nil {
+		return 0
+	}
+	count := 0
+	for _, e := range reg.Entries {
+		if e.RepoID == repoID {
+			count++
+		}
+	}
+	return count
 }
 
 func duplicateSyncRepoCounts(plan []engine.SyncResult) map[string]int {

--- a/internal/tui/metadata_forms.go
+++ b/internal/tui/metadata_forms.go
@@ -2,6 +2,7 @@
 package tui
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,27 @@ import (
 	"github.com/skaphos/repokeeper/internal/registry"
 	"github.com/skaphos/repokeeper/internal/repometa"
 )
+
+// metadataProposalUnchanged reports whether the proposal renders to exactly the
+// same canonical metadata already persisted at repoPath. It returns false when
+// the existing file can't be loaded or either side can't be rendered, so an
+// indeterminate comparison falls through to a normal (forced) save rather than
+// silently skipping a real change.
+func metadataProposalUnchanged(repoPath string, proposal *model.RepoMetadata) bool {
+	_, current, err := repometa.Load(repoPath)
+	if err != nil || current == nil {
+		return false
+	}
+	currentBytes, err := repometa.Render(current)
+	if err != nil {
+		return false
+	}
+	proposalBytes, err := repometa.Render(proposal)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(currentBytes, proposalBytes)
+}
 
 const (
 	metadataFieldName = iota
@@ -250,6 +272,15 @@ func saveRepoMetadataEditCmd(m tuiModel) tea.Cmd {
 		}
 		if proposal.RepoID != "" && proposal.RepoID != entry.RepoID {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: fmt.Errorf("repo metadata repo_id %q must match tracked repo_id %q", proposal.RepoID, entry.RepoID)}
+		}
+		// When a metadata file already exists, only rewrite it if the canonical
+		// content actually changes. An unchanged edit should not rewrite the
+		// repo-controlled file (which would dirty the repo's working tree), and
+		// this keeps the "no repo metadata changes" path reachable. If the
+		// existing file can't be loaded/rendered, fall through to the normal
+		// forced save.
+		if force && metadataProposalUnchanged(entry.Path, proposal) {
+			return repoMetadataEditDoneMsg{repoID: repoID, repoPath: repoPath, saved: false}
 		}
 		if _, err := repometa.Save(entry.Path, proposal, force); err != nil {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: err}

--- a/internal/tui/metadata_forms.go
+++ b/internal/tui/metadata_forms.go
@@ -28,16 +28,29 @@ const (
 	metadataFieldCount
 )
 
+// labelEditDoneMsg carries the outcome of the (pure, registry-free) parsing
+// step run in saveLabelEditCmd's Cmd goroutine. The actual registry mutation
+// and config.Save happen afterward in handleLabelEditDone, which runs on the
+// single Update goroutine, so the shared *registry.Registry is never touched
+// concurrently with the inspect goroutines started by streamStatusCmd.
 type labelEditDoneMsg struct {
-	repoID string
-	saved  bool
-	err    error
+	repoID   string
+	repoPath string
+	labels   map[string]string
+	err      error
 }
 
+// repoMetadataEditDoneMsg carries the outcome of saveRepoMetadataEditCmd.
+// refreshed is the freshly-computed repo metadata snapshot; applying it to
+// the registry entry and persisting config happen in
+// handleRepoMetadataEditDone on the Update goroutine, for the same reason as
+// labelEditDoneMsg above.
 type repoMetadataEditDoneMsg struct {
-	repoID string
-	saved  bool
-	err    error
+	repoID    string
+	repoPath  string
+	refreshed model.RepoStatus
+	saved     bool
+	err       error
 }
 
 func startLabelEdit(m tuiModel) (tea.Model, tea.Cmd) {
@@ -93,45 +106,85 @@ func startRepoMetadataEdit(m tuiModel) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// saveLabelEditCmd only parses the input the user typed. It deliberately
+// never touches the shared *registry.Registry or calls config.Save: those
+// happen in handleLabelEditDone on the Update goroutine, so this Cmd
+// goroutine cannot race with the registry reads done by in-flight
+// inspection Cmds (stream.go).
 func saveLabelEditCmd(m tuiModel) tea.Cmd {
 	repoID := m.labelRepoID
 	repoPath := m.labelRepoPath
 	input := m.labelInput
-	reg := m.engine.Registry()
-	cfg := m.engine.Config()
-	cfgPath := m.cfgPath
 	return func() tea.Msg {
-		if reg == nil {
-			return labelEditDoneMsg{repoID: repoID, err: fmt.Errorf("registry not available")}
-		}
-		if cfg == nil {
-			return labelEditDoneMsg{repoID: repoID, err: fmt.Errorf("config not available")}
-		}
-		if strings.TrimSpace(cfgPath) == "" {
-			return labelEditDoneMsg{repoID: repoID, err: fmt.Errorf("config path not available")}
-		}
 		labels, err := parseStringMapCSV(input, "label")
 		if err != nil {
 			return labelEditDoneMsg{repoID: repoID, err: err}
 		}
-		index := registryEntryIndexByIdentity(reg, repoID, repoPath)
-		if index < 0 {
-			return labelEditDoneMsg{repoID: repoID, err: fmt.Errorf("registry entry not found for %s", repoID)}
-		}
-		if sameStringMap(reg.Entries[index].Labels, labels) {
-			return labelEditDoneMsg{repoID: repoID, saved: false}
-		}
-		reg.Entries[index].Labels = labels
-		reg.Entries[index].LastSeen = time.Now()
-		reg.UpdatedAt = time.Now()
-		cfg.Registry = reg
-		if err := config.Save(cfg, cfgPath); err != nil {
-			return labelEditDoneMsg{repoID: repoID, err: err}
-		}
-		return labelEditDoneMsg{repoID: repoID, saved: true}
+		return labelEditDoneMsg{repoID: repoID, repoPath: repoPath, labels: labels}
 	}
 }
 
+func (m tuiModel) handleLabelEditDone(msg labelEditDoneMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.statusMsg = "label error: " + msg.err.Error()
+		m.statusIsError = true
+		return m, nil
+	}
+	m.mode = viewDetail
+	m.labelRepoID = ""
+	m.labelRepoPath = ""
+	m.labelInput = ""
+
+	reg := m.engine.Registry()
+	if reg == nil {
+		m.statusMsg = "label error: registry not available"
+		m.statusIsError = true
+		return m, nil
+	}
+	cfg := m.engine.Config()
+	if cfg == nil {
+		m.statusMsg = "label error: config not available"
+		m.statusIsError = true
+		return m, nil
+	}
+	if strings.TrimSpace(m.cfgPath) == "" {
+		m.statusMsg = "label error: config path not available"
+		m.statusIsError = true
+		return m, nil
+	}
+	index := registryEntryIndexByIdentity(reg, msg.repoID, msg.repoPath)
+	if index < 0 {
+		m.statusMsg = fmt.Sprintf("label error: registry entry not found for %s", msg.repoID)
+		m.statusIsError = true
+		return m, nil
+	}
+	if sameStringMap(reg.Entries[index].Labels, msg.labels) {
+		m.statusMsg = "no label changes"
+		m.statusIsError = false
+		return m, nil
+	}
+	reg.Entries[index].Labels = msg.labels
+	reg.Entries[index].LastSeen = time.Now()
+	reg.UpdatedAt = time.Now()
+	cfg.Registry = reg
+	if err := config.Save(cfg, m.cfgPath); err != nil {
+		m.statusMsg = "label error: " + err.Error()
+		m.statusIsError = true
+		return m, nil
+	}
+
+	m.statusMsg = "updated labels for " + msg.repoID
+	m.statusIsError = false
+	return startStatusRefresh(m)
+}
+
+// saveRepoMetadataEditCmd resolves the target registry entry and copies the
+// fields it needs (entry.Path, entry.RepoID) synchronously on the Update
+// goroutine before returning the Cmd, so the goroutine below only reads its
+// own local copies plus does file I/O for the repo's own metadata file. The
+// registry mutation and config.Save happen afterward in
+// handleRepoMetadataEditDone on the Update goroutine, for the same
+// concurrency-safety reason as saveLabelEditCmd above.
 func saveRepoMetadataEditCmd(m tuiModel) tea.Cmd {
 	repoID := m.metadataRepoID
 	repoPath := m.metadataRepoPath
@@ -144,24 +197,33 @@ func saveRepoMetadataEditCmd(m tuiModel) tea.Cmd {
 	providesInput := m.metadataProvides
 	relatedInput := m.metadataRelated
 	force := m.metadataExists
+
 	reg := m.engine.Registry()
-	cfg := m.engine.Config()
+	cfgAvailable := m.engine.Config() != nil
 	cfgPath := m.cfgPath
+
+	var entry registry.Entry
+	entryFound := false
+	if reg != nil {
+		if index := registryEntryIndexByIdentity(reg, repoID, repoPath); index >= 0 {
+			entry = reg.Entries[index]
+			entryFound = true
+		}
+	}
+
 	return func() tea.Msg {
 		if reg == nil {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: fmt.Errorf("registry not available")}
 		}
-		if cfg == nil {
+		if !cfgAvailable {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: fmt.Errorf("config not available")}
 		}
 		if strings.TrimSpace(cfgPath) == "" {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: fmt.Errorf("config path not available")}
 		}
-		index := registryEntryIndexByIdentity(reg, repoID, repoPath)
-		if index < 0 {
+		if !entryFound {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: fmt.Errorf("registry entry not found for %s", repoID)}
 		}
-		entry := reg.Entries[index]
 		labels, err := parseStringMapCSV(labelsInput, "label")
 		if err != nil {
 			return repoMetadataEditDoneMsg{repoID: repoID, err: err}
@@ -195,14 +257,55 @@ func saveRepoMetadataEditCmd(m tuiModel) tea.Cmd {
 		refreshed := model.RepoStatus{RepoID: entry.RepoID, Path: entry.Path}
 		registry.SeedRepoMetadataStatus(entry, &refreshed)
 		repometa.Apply(&refreshed)
-		registry.StoreRepoMetadataStatus(&entry, refreshed)
-		reg.Entries[index] = entry
-		cfg.Registry = reg
-		if err := config.Save(cfg, cfgPath); err != nil {
-			return repoMetadataEditDoneMsg{repoID: repoID, err: err}
-		}
-		return repoMetadataEditDoneMsg{repoID: repoID, saved: true}
+		return repoMetadataEditDoneMsg{repoID: repoID, repoPath: repoPath, refreshed: refreshed, saved: true}
 	}
+}
+
+func (m tuiModel) handleRepoMetadataEditDone(msg repoMetadataEditDoneMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.statusMsg = "repo metadata error: " + msg.err.Error()
+		m.statusIsError = true
+		return m, nil
+	}
+	m = resetRepoMetadataEditState(m)
+	m.mode = viewDetail
+	if !msg.saved {
+		m.statusMsg = "no repo metadata changes"
+		m.statusIsError = false
+		return m, nil
+	}
+
+	reg := m.engine.Registry()
+	if reg == nil {
+		m.statusMsg = "repo metadata error: registry not available"
+		m.statusIsError = true
+		return m, nil
+	}
+	cfg := m.engine.Config()
+	if cfg == nil {
+		m.statusMsg = "repo metadata error: config not available"
+		m.statusIsError = true
+		return m, nil
+	}
+	index := registryEntryIndexByIdentity(reg, msg.repoID, msg.repoPath)
+	if index < 0 {
+		m.statusMsg = fmt.Sprintf("repo metadata error: registry entry not found for %s", msg.repoID)
+		m.statusIsError = true
+		return m, nil
+	}
+	entry := reg.Entries[index]
+	registry.StoreRepoMetadataStatus(&entry, msg.refreshed)
+	reg.Entries[index] = entry
+	cfg.Registry = reg
+	if err := config.Save(cfg, m.cfgPath); err != nil {
+		m.statusMsg = "repo metadata error: " + err.Error()
+		m.statusIsError = true
+		return m, nil
+	}
+
+	m.statusMsg = "updated repo metadata for " + msg.repoID
+	m.statusIsError = false
+	return startStatusRefresh(m)
 }
 
 func renderLabelEditView(m tuiModel) string {

--- a/internal/tui/metadata_forms_test.go
+++ b/internal/tui/metadata_forms_test.go
@@ -2,6 +2,7 @@
 package tui
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/skaphos/repokeeper/internal/config"
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/registry"
+	"github.com/skaphos/repokeeper/internal/repometa"
 )
 
 func TestRenderMetadataViewsAndHelpers(t *testing.T) {
@@ -275,5 +277,81 @@ func TestEditKeyHandlersAndMetadataFieldMutationHelpers(t *testing.T) {
 	nm = next.(tuiModel)
 	if nm.mode != viewDetail || nm.metadataRepoID != "" || nm.metadataLabelsInput != "" || nm.statusMsg != "" || nm.statusIsError {
 		t.Fatalf("expected escaped metadata editor reset, got %+v", nm)
+	}
+}
+
+// saveRepoMetadataEditCmd must not rewrite an existing metadata file when the
+// proposed metadata is unchanged: an unchanged edit should report saved=false
+// (so the "no repo metadata changes" path is reachable) and leave the
+// repo-controlled file byte-for-byte identical rather than dirtying the tree.
+func TestSaveRepoMetadataEditCmdSkipsUnchangedMetadata(t *testing.T) {
+	tmp := t.TempDir()
+	repoPath := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	reg := &registry.Registry{Entries: []registry.Entry{{RepoID: "acme/a", Path: repoPath, Status: registry.StatusPresent}}}
+	cfg := config.DefaultConfig()
+	cfg.Registry = reg
+	eng := &mockEngine{reg: reg, cfg: &cfg}
+	base := tuiModel{
+		metadataRepoID:          "acme/a",
+		metadataRepoPath:        repoPath,
+		metadataField:           metadataFieldRelated,
+		metadataName:            "Repo A",
+		metadataRepoIDAssertion: "acme/a",
+		metadataLabelsInput:     "team=platform",
+		engine:                  eng,
+		cfgPath:                 filepath.Join(tmp, ".repokeeper.yaml"),
+	}
+
+	// First save creates the file (no existing file, so force=false).
+	first := base
+	first.metadataExists = false
+	msg1, ok := saveRepoMetadataEditCmd(first)().(repoMetadataEditDoneMsg)
+	if !ok || msg1.err != nil {
+		t.Fatalf("first save: ok=%v err=%v", ok, msg1.err)
+	}
+	if !msg1.saved {
+		t.Fatal("expected first save to persist (saved=true)")
+	}
+
+	metaPath, _, err := repometa.Load(repoPath)
+	if err != nil {
+		t.Fatalf("load after first save: %v", err)
+	}
+	before, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+
+	// Re-saving identical metadata must be a no-op that does not rewrite the file.
+	second := base
+	second.metadataExists = true
+	msg2, ok := saveRepoMetadataEditCmd(second)().(repoMetadataEditDoneMsg)
+	if !ok || msg2.err != nil {
+		t.Fatalf("second save: ok=%v err=%v", ok, msg2.err)
+	}
+	if msg2.saved {
+		t.Fatal("expected unchanged re-save to be a no-op (saved=false)")
+	}
+	after, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("metadata file was rewritten despite no change:\nbefore=%q\nafter=%q", before, after)
+	}
+
+	// A genuine change must still persist.
+	third := base
+	third.metadataExists = true
+	third.metadataName = "Repo A Renamed"
+	msg3, ok := saveRepoMetadataEditCmd(third)().(repoMetadataEditDoneMsg)
+	if !ok || msg3.err != nil {
+		t.Fatalf("third save: ok=%v err=%v", ok, msg3.err)
+	}
+	if !msg3.saved {
+		t.Fatal("expected a changed re-save to persist (saved=true)")
 	}
 }

--- a/internal/tui/metadata_forms_test.go
+++ b/internal/tui/metadata_forms_test.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/skaphos/repokeeper/internal/config"
 	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/registry"
 )
@@ -110,6 +112,104 @@ func TestRenderMetadataViewsAndHelpers(t *testing.T) {
 	}
 	if got := cloneMetadataStringMap(nil); got != nil {
 		t.Fatalf("expected nil map clone, got %+v", got)
+	}
+}
+
+// TestSaveLabelEditCmdDoesNotRaceWithConcurrentRegistryReads exercises the
+// concurrency fix directly: stream.go's inspect Cmds read the shared
+// *registry.Registry (via FindEntry) from goroutines that can still be in
+// flight while a label/metadata edit is being saved. Before the fix,
+// saveLabelEditCmd's returned Cmd wrote straight into reg.Entries and called
+// config.Save from inside that same goroutine, racing with concurrent
+// reads. Run with -race: this test fails against the pre-fix code and
+// passes against the fix, which confines the write to the Update-goroutine
+// handler (handleLabelEditDone) and keeps the Cmd goroutine registry-free.
+func TestSaveLabelEditCmdDoesNotRaceWithConcurrentRegistryReads(t *testing.T) {
+	reg := &registry.Registry{Entries: []registry.Entry{{RepoID: "acme/a", Path: "/tmp/a", Status: registry.StatusPresent}}}
+	cfg := config.DefaultConfig()
+	cfg.Registry = reg
+	eng := &mockEngine{reg: reg, cfg: &cfg}
+	m := tuiModel{labelRepoID: "acme/a", labelRepoPath: "/tmp/a", labelInput: "team=platform", engine: eng}
+
+	cmd := saveLabelEditCmd(m)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = reg.FindEntry("acme/a", "/tmp/a")
+			}
+		}
+	}()
+
+	msg, ok := cmd().(labelEditDoneMsg)
+	close(stop)
+	wg.Wait()
+
+	if !ok {
+		t.Fatalf("expected labelEditDoneMsg, got %T", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+}
+
+// TestSaveRepoMetadataEditCmdDoesNotRaceWithConcurrentRegistryReads is the
+// analogous race test for saveRepoMetadataEditCmd; see
+// TestSaveLabelEditCmdDoesNotRaceWithConcurrentRegistryReads for details.
+func TestSaveRepoMetadataEditCmdDoesNotRaceWithConcurrentRegistryReads(t *testing.T) {
+	tmp := t.TempDir()
+	repoPath := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	reg := &registry.Registry{Entries: []registry.Entry{{RepoID: "acme/a", Path: repoPath, Status: registry.StatusPresent}}}
+	cfg := config.DefaultConfig()
+	cfg.Registry = reg
+	eng := &mockEngine{reg: reg, cfg: &cfg}
+	m := tuiModel{
+		metadataRepoID:          "acme/a",
+		metadataRepoPath:        repoPath,
+		metadataField:           metadataFieldRelated,
+		metadataName:            "Repo A",
+		metadataRepoIDAssertion: "acme/a",
+		metadataLabelsInput:     "team=platform",
+		engine:                  eng,
+		cfgPath:                 filepath.Join(tmp, ".repokeeper.yaml"),
+	}
+
+	cmd := saveRepoMetadataEditCmd(m)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = reg.FindEntry("acme/a", repoPath)
+			}
+		}
+	}()
+
+	msg, ok := cmd().(repoMetadataEditDoneMsg)
+	close(stop)
+	wg.Wait()
+
+	if !ok {
+		t.Fatalf("expected repoMetadataEditDoneMsg, got %T", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
 	}
 }
 

--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -23,7 +23,7 @@ func renderModalButtons(options []string, selected int) string {
 	return b.String()
 }
 
-func modalMoveLeft(m tuiModel, n int) tuiModel {
+func modalMoveLeft(m tuiModel) tuiModel {
 	if m.modalCursor > 0 {
 		m.modalCursor--
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,6 +3,7 @@ package tui
 
 import (
 	"context"
+	"sync/atomic"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/skaphos/repokeeper/internal/engine"
@@ -35,7 +36,14 @@ type tuiModel struct {
 	engine  EngineAPI
 	cfgPath string
 	ctx     context.Context
-	program *tea.Program
+
+	// program is a shared, atomically-guarded reference to the running
+	// *tea.Program. bubbletea's Elm architecture copies tuiModel by value on
+	// every Update, so a plain *tea.Program field set only once after
+	// tea.NewProgram would never be visible to the model instance the
+	// program actually drives. All copies share this same pointer, so
+	// storing into it once at startup makes the value visible everywhere.
+	program *atomic.Pointer[tea.Program]
 
 	mode          viewMode
 	width, height int
@@ -55,7 +63,6 @@ type tuiModel struct {
 	selected map[string]bool
 
 	syncPlan     []engine.SyncResult
-	syncResults  []engine.SyncResult
 	syncProgress map[string]engine.SyncResult
 	syncDone     bool
 	syncErr      error
@@ -119,6 +126,7 @@ func newModel(ctx context.Context, eng EngineAPI, reg *registry.Registry, cfgPat
 		engine:             eng,
 		cfgPath:            cfgPath,
 		ctx:                ctx,
+		program:            new(atomic.Pointer[tea.Program]),
 		repos:              repos,
 		loading:            true,
 		mode:               viewList,

--- a/internal/tui/model_internal_test.go
+++ b/internal/tui/model_internal_test.go
@@ -18,6 +18,16 @@ type mockEngine struct {
 	statusErr    error
 	reg          *registry.Registry
 	cfg          *config.Config
+
+	// lastXCtx records the context each write-side method most recently
+	// received, so tests can verify callers thread through the model's
+	// context (finding: several action Cmds used to hardcode
+	// context.Background(), so cancelling/quitting never stopped an
+	// in-flight clone/delete/reset/repair).
+	lastDeleteCtx context.Context
+	lastResetCtx  context.Context
+	lastRepairCtx context.Context
+	lastCloneCtx  context.Context
 }
 
 func (e *mockEngine) Status(ctx context.Context, opts engine.StatusOptions) (*model.StatusReport, error) {
@@ -43,13 +53,19 @@ func (e *mockEngine) InspectRepo(ctx context.Context, path string) (*model.RepoS
 }
 
 func (e *mockEngine) RepairUpstream(ctx context.Context, repoID, cfgPath string) (engine.RepairUpstreamResult, error) {
+	e.lastRepairCtx = ctx
 	return engine.RepairUpstreamResult{}, nil
 }
-func (e *mockEngine) ResetRepo(ctx context.Context, repoID, cfgPath string) error { return nil }
+func (e *mockEngine) ResetRepo(ctx context.Context, repoID, cfgPath string) error {
+	e.lastResetCtx = ctx
+	return nil
+}
 func (e *mockEngine) DeleteRepo(ctx context.Context, repoID, cfgPath string, deleteFiles bool) error {
+	e.lastDeleteCtx = ctx
 	return nil
 }
 func (e *mockEngine) CloneAndRegister(ctx context.Context, remoteURL, targetPath, cfgPath string, mirror bool) error {
+	e.lastCloneCtx = ctx
 	return nil
 }
 
@@ -294,6 +310,33 @@ func TestEscInListClearsFilter(t *testing.T) {
 	next := nm.(tuiModel)
 	if next.filterText != "" {
 		t.Fatalf("expected filterText='', got %q", next.filterText)
+	}
+}
+
+func TestModelProgramRefVisibleAcrossValueCopies(t *testing.T) {
+	t.Parallel()
+
+	// bubbletea's Elm architecture stores/returns tuiModel by value: every
+	// Update call operates on (and returns) a copy. tea.NewProgram(m, ...)
+	// captures its own copy of m before RunWithEngine can set the program
+	// reference, so a plain *tea.Program field set only afterward would
+	// never be observed by the copy the running program actually drives.
+	// program must therefore be a shared pointer: storing through it from
+	// one copy must be visible from every other copy, including ones taken
+	// before the store.
+	ctx := context.Background()
+	m := newModel(ctx, &mockEngine{}, nil, "")
+
+	copyOfM := m // simulates tea.NewProgram's internal capture of the model
+	if got := copyOfM.program.Load(); got != nil {
+		t.Fatalf("expected no program stored yet, got %v", got)
+	}
+
+	p := tea.NewProgram(copyOfM, tea.WithContext(ctx))
+	m.program.Store(p)
+
+	if got := copyOfM.program.Load(); got != p {
+		t.Fatalf("expected the pre-existing model copy to observe the stored *tea.Program, got %v want %v", got, p)
 	}
 }
 

--- a/internal/tui/repair.go
+++ b/internal/tui/repair.go
@@ -15,9 +15,9 @@ type repairDoneMsg struct {
 	err    error
 }
 
-func repairUpstreamCmd(eng EngineAPI, repoID, cfgPath string) tea.Cmd {
+func repairUpstreamCmd(ctx context.Context, eng EngineAPI, repoID, cfgPath string) tea.Cmd {
 	return func() tea.Msg {
-		result, err := eng.RepairUpstream(context.Background(), repoID, cfgPath)
+		result, err := eng.RepairUpstream(ctx, repoID, cfgPath)
 		return repairDoneMsg{result: result, err: err}
 	}
 }
@@ -36,11 +36,8 @@ func resolveRepairTarget(m tuiModel) (repoID, targetUpstream string, err error) 
 	}
 
 	var entryBranch string
-	for _, e := range reg.Entries {
-		if e.RepoID == repo.RepoID {
-			entryBranch = e.Branch
-			break
-		}
+	if index := registryEntryIndexByIdentity(reg, repo.RepoID, repo.Path); index >= 0 {
+		entryBranch = reg.Entries[index].Branch
 	}
 
 	remote := strings.TrimSpace(repo.PrimaryRemote)

--- a/internal/tui/reset_action.go
+++ b/internal/tui/reset_action.go
@@ -14,9 +14,9 @@ type resetDoneMsg struct {
 	err    error
 }
 
-func resetRepoCmd(eng EngineAPI, repoID, cfgPath string) tea.Cmd {
+func resetRepoCmd(ctx context.Context, eng EngineAPI, repoID, cfgPath string) tea.Cmd {
 	return func() tea.Msg {
-		err := eng.ResetRepo(context.Background(), repoID, cfgPath)
+		err := eng.ResetRepo(ctx, repoID, cfgPath)
 		return resetDoneMsg{repoID: repoID, err: err}
 	}
 }

--- a/internal/tui/stream_test.go
+++ b/internal/tui/stream_test.go
@@ -189,6 +189,50 @@ func TestHandleRepoStatusWritesRepoMetadataSnapshotBackToRegistry(t *testing.T) 
 	}
 }
 
+func TestHandleRepoStatusIgnoresStaleMessageForDeletedRepo(t *testing.T) {
+	t.Parallel()
+
+	// Simulate: "acme/gone" was deleted (removed from both m.repos, by
+	// handleDeleteDone, and from the registry, by engine.DeleteRepo) while
+	// its inspection from an earlier streamStatusCmd batch was still in
+	// flight. The late repoStatusMsg must not resurrect it as a ghost row.
+	reg := &registry.Registry{Entries: []registry.Entry{{RepoID: "acme/keep", Path: "/work/keep", Status: registry.StatusPresent}}}
+	m := tuiModel{
+		repos:              []model.RepoStatus{{RepoID: "acme/keep", Path: "/work/keep"}},
+		loading:            true,
+		pendingInspections: 1,
+		engine:             &mockEngine{reg: reg},
+	}
+
+	nm, cmd := m.handleRepoStatus(repoStatusMsg{status: model.RepoStatus{RepoID: "acme/gone", Path: "/work/gone"}})
+	if cmd != nil {
+		t.Fatal("expected nil cmd")
+	}
+	next := nm.(tuiModel)
+	if len(next.repos) != 1 {
+		t.Fatalf("expected stale status for a deleted repo to be dropped, got %d rows: %+v", len(next.repos), next.repos)
+	}
+	if next.loading {
+		t.Fatal("expected loading=false after accounting for the dropped, last pending inspection")
+	}
+}
+
+func TestHandleRepoStatusAppendsRowStillInRegistry(t *testing.T) {
+	t.Parallel()
+
+	// A row absent from m.repos but present in the registry (e.g. the add
+	// flow, which streams status for every registry entry including the
+	// brand-new one) must still be appended normally.
+	reg := &registry.Registry{Entries: []registry.Entry{{RepoID: "acme/new", Path: "/work/new", Status: registry.StatusPresent}}}
+	m := tuiModel{engine: &mockEngine{reg: reg}}
+
+	nm, _ := m.handleRepoStatus(repoStatusMsg{status: model.RepoStatus{RepoID: "acme/new", Path: "/work/new"}})
+	next := nm.(tuiModel)
+	if len(next.repos) != 1 {
+		t.Fatalf("expected newly tracked repo to be appended, got %d rows", len(next.repos))
+	}
+}
+
 func TestEmptyRegistryRenderNoRepos(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/sync_test.go
+++ b/internal/tui/sync_test.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/skaphos/repokeeper/internal/engine"
 	"github.com/skaphos/repokeeper/internal/model"
+	"github.com/skaphos/repokeeper/internal/registry"
 )
 
 func TestToggleSelectionAddAndRemove(t *testing.T) {
@@ -239,5 +240,27 @@ func TestHandleSyncProgressKey_WhenDoneReturnsToList(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("expected refresh cmd after returning to list")
+	}
+}
+
+func TestHandleSyncProgressKey_WhenDoneSetsPendingInspections(t *testing.T) {
+	t.Parallel()
+
+	// Without pendingInspections tracking the number of repoStatusMsg
+	// deliveries streamStatusCmd will produce, handleRepoStatus clears
+	// loading after the first of N streamed messages instead of the last.
+	reg := &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "a", Path: "/tmp/a", Status: registry.StatusPresent},
+		{RepoID: "b", Path: "/tmp/b", Status: registry.StatusPresent},
+	}}
+	eng := &mockEngine{reg: reg}
+	m := tuiModel{mode: viewProgress, syncDone: true, engine: eng}
+	nm, cmd := m.handleSyncProgressKey(tea.KeyPressMsg{Code: 'q'})
+	next := nm.(tuiModel)
+	if cmd == nil {
+		t.Fatal("expected refresh cmd after returning to list")
+	}
+	if !next.loading || next.pendingInspections != 2 {
+		t.Fatalf("expected loading=true and pendingInspections=2, got loading=%v pendingInspections=%d", next.loading, next.pendingInspections)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -28,7 +28,11 @@ func Run(ctx context.Context, cfg *config.Config, reg *registry.Registry, cfgPat
 func RunWithEngine(ctx context.Context, eng EngineAPI, reg *registry.Registry, cfgPath string) error {
 	m := newModel(ctx, eng, reg, cfgPath)
 	p := tea.NewProgram(m, tea.WithContext(ctx))
-	m.program = p
+	// m.program is a pointer shared by every value-copy of the model
+	// (including the one tea.NewProgram just captured), so storing into it
+	// here makes the running program visible to Update-goroutine Cmds such
+	// as executeSyncCmd without needing a pointer-receiver model.
+	m.program.Store(p)
 	_, err := p.Run()
 	return err
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -3,6 +3,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -123,12 +124,7 @@ func (m tuiModel) handleListKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "f5":
-		m.loading = true
-		reg := m.engine.Registry()
-		if reg != nil {
-			m.pendingInspections = len(reg.Entries)
-		}
-		return m, refreshStatusCmd(m.context(), m.engine)
+		return startStatusRefresh(m)
 
 	case "esc":
 		if m.filterText != "" {
@@ -219,7 +215,7 @@ func (m tuiModel) handleSyncPlanKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	left, right := isModalNav(msg)
 	if left {
-		m = modalMoveLeft(m, syncPlanOptionCount)
+		m = modalMoveLeft(m)
 		return m, nil
 	}
 	if right {
@@ -252,14 +248,24 @@ func (m tuiModel) handleSyncProgressKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	if m.syncDone {
 		m.mode = viewList
 		m.syncPlan = nil
-		m.syncResults = nil
 		m.syncProgress = nil
 		m.syncDone = false
 		m.syncErr = nil
-		m.loading = true
-		return m, refreshStatusCmd(m.context(), m.engine)
+		return startStatusRefresh(m)
 	}
 	return m, nil
+}
+
+// startStatusRefresh puts the model into a loading state and returns the
+// command that re-inspects every registry entry, recording how many
+// repoStatusMsg deliveries to expect so handleRepoStatus clears loading at
+// the right time instead of after the first streamed message.
+func startStatusRefresh(m tuiModel) (tea.Model, tea.Cmd) {
+	m.loading = true
+	if reg := m.engine.Registry(); reg != nil {
+		m.pendingInspections = len(reg.Entries)
+	}
+	return m, refreshStatusCmd(m.context(), m.engine)
 }
 
 func (m tuiModel) moveCursor(delta int) tuiModel {
@@ -341,8 +347,12 @@ func executeSyncCmd(m tuiModel) tea.Cmd {
 	ctx := m.context()
 	plan := m.syncPlan
 	eng := m.engine
-	prog := m.program
+	progRef := m.program
 	return func() tea.Msg {
+		var prog *tea.Program
+		if progRef != nil {
+			prog = progRef.Load()
+		}
 		onStart := func(r engine.SyncResult) {
 			if prog != nil {
 				prog.Send(syncProgressMsg{result: r, started: true})
@@ -403,7 +413,6 @@ func (m tuiModel) handleSyncProgress(msg syncProgressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m tuiModel) handleSyncDone(msg syncDoneMsg) (tea.Model, tea.Cmd) {
-	m.syncResults = msg.results
 	m.syncErr = msg.err
 	m.syncDone = true
 	if m.syncProgress == nil {
@@ -418,8 +427,18 @@ func (m tuiModel) handleSyncDone(msg syncDoneMsg) (tea.Model, tea.Cmd) {
 func (m tuiModel) handleRepoStatus(msg repoStatusMsg) (tea.Model, tea.Cmd) {
 	if index := findRepoStatusIndex(m.repos, msg.status); index >= 0 {
 		m.repos[index] = msg.status
-	} else {
+	} else if repoStatusStillTracked(m.engine, msg.status) {
 		m.repos = append(m.repos, msg.status)
+	} else {
+		// A late repoStatusMsg for a row that's no longer in m.repos (e.g. it
+		// was deleted while its inspection was still in flight) and is no
+		// longer in the registry either: drop it instead of resurrecting a
+		// ghost row.
+		m.pendingInspections--
+		if m.pendingInspections <= 0 {
+			m.loading = false
+		}
+		return m, nil
 	}
 	if m.engine != nil {
 		writeRepoMetadataSnapshot(m.engine.Registry(), msg.status)
@@ -432,6 +451,22 @@ func (m tuiModel) handleRepoStatus(msg repoStatusMsg) (tea.Model, tea.Cmd) {
 		m.loading = false
 	}
 	return m, nil
+}
+
+// repoStatusStillTracked reports whether status still corresponds to a
+// registry entry. It is permissive (true) when the engine or registry is
+// unavailable so genuinely new rows (e.g. from the add flow, where the
+// registry already contains the entry before streamStatusCmd is dispatched)
+// keep appearing normally.
+func repoStatusStillTracked(eng EngineAPI, status model.RepoStatus) bool {
+	if eng == nil {
+		return true
+	}
+	reg := eng.Registry()
+	if reg == nil {
+		return true
+	}
+	return reg.FindEntry(status.RepoID, status.Path) != nil
 }
 
 func writeRepoMetadataSnapshot(reg *registry.Registry, status model.RepoStatus) {
@@ -452,8 +487,14 @@ func (m tuiModel) startReset() (tea.Model, tea.Cmd) {
 	if len(list) == 0 || m.cursor >= len(list) {
 		return m, nil
 	}
+	repo := list[m.cursor]
+	if m.engine != nil && repoIDRowCount(m.engine.Registry(), repo.RepoID) > 1 {
+		m.statusMsg = fmt.Sprintf("repo_id %q is ambiguous across multiple checkouts; resolve with 'e' before resetting", repo.RepoID)
+		m.statusIsError = true
+		return m, nil
+	}
 	m.mode = viewResetConfirm
-	m.resetRepoID = list[m.cursor].RepoID
+	m.resetRepoID = repo.RepoID
 	m.modalCursor = 0
 	return m, nil
 }
@@ -469,7 +510,7 @@ func (m tuiModel) handleResetConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	}
 	left, right := isModalNav(msg)
 	if left {
-		m = modalMoveLeft(m, resetOptionCount)
+		m = modalMoveLeft(m)
 		return m, nil
 	}
 	if right {
@@ -482,7 +523,7 @@ func (m tuiModel) handleResetConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 			m.mode = viewList
 			m.resetRepoID = ""
 			m.modalCursor = 0
-			return m, resetRepoCmd(m.engine, repoID, m.cfgPath)
+			return m, resetRepoCmd(m.context(), m.engine, repoID, m.cfgPath)
 		}
 		m.mode = viewList
 		m.resetRepoID = ""
@@ -499,13 +540,7 @@ func (m tuiModel) handleResetDone(msg resetDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	m.statusMsg = "reset: " + msg.repoID
 	m.statusIsError = false
-	m.loading = true
-	reg := m.engine.Registry()
-	if reg != nil && len(reg.Entries) > 0 {
-		m.pendingInspections = len(reg.Entries)
-		return m, streamStatusCmd(m.context(), m.engine, reg.Entries)
-	}
-	return m, loadStatusCmd(m.context(), m.engine)
+	return startStatusRefresh(m)
 }
 
 func (m tuiModel) startDelete() (tea.Model, tea.Cmd) {
@@ -513,9 +548,15 @@ func (m tuiModel) startDelete() (tea.Model, tea.Cmd) {
 	if len(list) == 0 || m.cursor >= len(list) {
 		return m, nil
 	}
+	repo := list[m.cursor]
+	if m.engine != nil && repoIDRowCount(m.engine.Registry(), repo.RepoID) > 1 {
+		m.statusMsg = fmt.Sprintf("repo_id %q is ambiguous across multiple checkouts; resolve with 'e' before deleting", repo.RepoID)
+		m.statusIsError = true
+		return m, nil
+	}
 	m.mode = viewDeleteConfirm
-	m.deleteRepoID = list[m.cursor].RepoID
-	m.deleteRepoPath = list[m.cursor].Path
+	m.deleteRepoID = repo.RepoID
+	m.deleteRepoPath = repo.Path
 	m.modalCursor = 0
 	return m, nil
 }
@@ -532,7 +573,7 @@ func (m tuiModel) handleDeleteConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	}
 	left, right := isModalNav(msg)
 	if left {
-		m = modalMoveLeft(m, deleteOptionCount)
+		m = modalMoveLeft(m)
 		return m, nil
 	}
 	if right {
@@ -548,7 +589,8 @@ func (m tuiModel) handleDeleteConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			m.deleteRepoPath = ""
 			m.modalCursor = 0
 			m.cursor = 0
-			return m, deleteRepoCmd(m.engine, repoID, m.cfgPath, false)
+			m.offset = 0
+			return m, deleteRepoCmd(m.context(), m.engine, repoID, m.cfgPath, false)
 		case 2:
 			repoID := m.deleteRepoID
 			m.mode = viewList
@@ -556,7 +598,8 @@ func (m tuiModel) handleDeleteConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			m.deleteRepoPath = ""
 			m.modalCursor = 0
 			m.cursor = 0
-			return m, deleteRepoCmd(m.engine, repoID, m.cfgPath, true)
+			m.offset = 0
+			return m, deleteRepoCmd(m.context(), m.engine, repoID, m.cfgPath, true)
 		default:
 			m.mode = viewList
 			m.deleteRepoID = ""
@@ -633,7 +676,7 @@ func (m tuiModel) handleAddKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.mode = viewList
-			return m, cloneAndRegisterCmd(m.engine, url, path, m.cfgPath, m.addMirror)
+			return m, cloneAndRegisterCmd(m.context(), m.engine, url, path, m.cfgPath, m.addMirror)
 		}
 		return m, nil
 
@@ -690,13 +733,7 @@ func (m tuiModel) handleAddDone(msg addDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	m.statusMsg = "added: " + msg.repoID
 	m.statusIsError = false
-	m.loading = true
-	reg := m.engine.Registry()
-	if reg != nil && len(reg.Entries) > 0 {
-		m.pendingInspections = len(reg.Entries)
-		return m, streamStatusCmd(m.context(), m.engine, reg.Entries)
-	}
-	return m, loadStatusCmd(m.context(), m.engine)
+	return startStatusRefresh(m)
 }
 
 func (m tuiModel) handleLabelEditKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -827,50 +864,15 @@ func resetRepoMetadataEditState(m tuiModel) tuiModel {
 	return m
 }
 
-func (m tuiModel) handleLabelEditDone(msg labelEditDoneMsg) (tea.Model, tea.Cmd) {
-	if msg.err != nil {
-		m.statusMsg = "label error: " + msg.err.Error()
-		m.statusIsError = true
-		return m, nil
-	}
-	m.mode = viewDetail
-	m.labelRepoID = ""
-	m.labelRepoPath = ""
-	m.labelInput = ""
-	if !msg.saved {
-		m.statusMsg = "no label changes"
-		m.statusIsError = false
-		return m, nil
-	}
-	m.statusMsg = "updated labels for " + msg.repoID
-	m.statusIsError = false
-	m.loading = true
-	return m, refreshStatusCmd(m.context(), m.engine)
-}
-
-func (m tuiModel) handleRepoMetadataEditDone(msg repoMetadataEditDoneMsg) (tea.Model, tea.Cmd) {
-	if msg.err != nil {
-		m.statusMsg = "repo metadata error: " + msg.err.Error()
-		m.statusIsError = true
-		return m, nil
-	}
-	m = resetRepoMetadataEditState(m)
-	m.mode = viewDetail
-	if !msg.saved {
-		m.statusMsg = "no repo metadata changes"
-		m.statusIsError = false
-		return m, nil
-	}
-	m.statusMsg = "updated repo metadata for " + msg.repoID
-	m.statusIsError = false
-	m.loading = true
-	return m, refreshStatusCmd(m.context(), m.engine)
-}
-
 func (m tuiModel) startRepair() (tea.Model, tea.Cmd) {
 	repoID, target, err := resolveRepairTarget(m)
 	if err != nil {
 		m.statusMsg = err.Error()
+		m.statusIsError = true
+		return m, nil
+	}
+	if repoIDRowCount(m.engine.Registry(), repoID) > 1 {
+		m.statusMsg = fmt.Sprintf("repo_id %q is ambiguous across multiple checkouts; resolve with 'e' before repairing", repoID)
 		m.statusIsError = true
 		return m, nil
 	}
@@ -893,7 +895,7 @@ func (m tuiModel) handleRepairConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	}
 	left, right := isModalNav(msg)
 	if left {
-		m = modalMoveLeft(m, repairOptionCount)
+		m = modalMoveLeft(m)
 		return m, nil
 	}
 	if right {
@@ -913,7 +915,7 @@ func (m tuiModel) handleRepairConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		m.repairRepoID = ""
 		m.repairTargetUpstream = ""
 		m.modalCursor = 0
-		return m, repairUpstreamCmd(m.engine, repoID, m.cfgPath)
+		return m, repairUpstreamCmd(m.context(), m.engine, repoID, m.cfgPath)
 	}
 	return m, nil
 }
@@ -937,13 +939,7 @@ func (m tuiModel) handleEditDone(msg editDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	m.statusMsg = "updated " + msg.repoID
 	m.statusIsError = false
-	m.loading = true
-	reg := m.engine.Registry()
-	if reg != nil && len(reg.Entries) > 0 {
-		m.pendingInspections = len(reg.Entries)
-		return m, streamStatusCmd(m.context(), m.engine, reg.Entries)
-	}
-	return m, loadStatusCmd(m.context(), m.engine)
+	return startStatusRefresh(m)
 }
 
 func (m tuiModel) handleRepairDone(msg repairDoneMsg) (tea.Model, tea.Cmd) {
@@ -955,20 +951,12 @@ func (m tuiModel) handleRepairDone(msg repairDoneMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.statusIsError = false
-	switch msg.result.Action {
-	case "repaired":
-		m.statusMsg = "repaired: " + msg.result.RepoID
-		m.loading = true
-		reg := m.engine.Registry()
-		if reg != nil && len(reg.Entries) > 0 {
-			m.pendingInspections = len(reg.Entries)
-			return m, streamStatusCmd(m.context(), m.engine, reg.Entries)
-		}
-		return m, loadStatusCmd(m.context(), m.engine)
-	default:
+	if msg.result.Action != "repaired" {
 		m.statusMsg = msg.result.Action + ": " + msg.result.RepoID
+		return m, nil
 	}
-	return m, nil
+	m.statusMsg = "repaired: " + msg.result.RepoID
+	return startStatusRefresh(m)
 }
 
 func refreshStatusCmd(ctx context.Context, eng EngineAPI) tea.Cmd {


### PR DESCRIPTION
## Summary

Resolves 9 verified code-review findings in `internal/tui/`, scoped strictly to that package (no changes to `internal/registry` or `internal/engine`, and no EngineAPI signature changes that would require touching them).

## Findings fixed

1. **P1 — nil `*tea.Program` drops live sync progress** (`tui.go:29-31`, `update.go` `executeSyncCmd`). `tea.NewProgram(m, ...)` copies the model before `m.program = p` could run, so the running model's `program` field stayed nil forever and progress `Send` calls were silently no-ops. Fixed by making `program` a shared `*atomic.Pointer[tea.Program]` allocated once in `newModel` — every value-copy of `tuiModel` (including the one `tea.NewProgram` captures) shares the same pointer, so a single `Store` after `NewProgram` is visible everywhere. Verified with `TestModelProgramRefVisibleAcrossValueCopies`.

2. **P1 — unsynchronized registry writes from Cmd goroutines** (`stream.go` reads via `FindEntry`, `metadata_forms.go` `save*` writes + `config.Save`). `saveLabelEditCmd`/`saveRepoMetadataEditCmd` used to mutate `reg.Entries` and call `config.Save` from inside the `tea.Cmd` goroutine, racing with concurrent inspect-goroutine reads. Restructured so the Cmd goroutine only does registry-free work (parsing, and for repo metadata, writing the repo's own metadata file using an entry snapshot captured synchronously beforehand); the actual registry mutation + `config.Save` now happen in `handleLabelEditDone`/`handleRepoMetadataEditDone`, which only ever run on the single Update goroutine. Verified with two `-race` tests that fail against the pre-fix code (busy-loop `reg.FindEntry` reader concurrent with the save Cmd).

3. **P2 — repo-controlled metadata rendered raw (terminal injection)** (`detail.go`). `RepoMetadata` is loaded from a file inside the cloned repo, so a hostile upstream fully controls those strings. Added `sanitizeMetadataText`, which strips C0 control bytes and whole ANSI escape sequences (CSI and OSC forms, not just the leading ESC byte), applied to every RepoMetadata-derived field before rendering.

4. **P2 — stale list offset after delete** (`update.go` `handleDeleteConfirmKey`). Cursor was reset to 0 but offset wasn't, so deleting near the bottom of a long list could render an empty/scrolled-past view. Offset is now reset alongside cursor.

5. **P2 — duplicate repo_id row actions act on the wrong row** (`edit_action.go`, `repair.go`, `update.go`). `prepareEditCmd` and `resolveRepairTarget` resolved by first repo_id match, ignoring the selected row's path; both now use `registryEntryIndexByIdentity` (path first, repo_id fallback), matching what `metadata_forms.go` already did. `deleteRepoCmd`/`resetRepoCmd`/`repairUpstreamCmd` only take a bare repo_id (that's `EngineAPI`'s existing shape — see "Deferred" below), so they genuinely cannot disambiguate two checkouts sharing a repo_id; `startDelete`/`startReset`/`startRepair` now refuse with a clear status message when repo_id is ambiguous, rather than silently acting on a possibly-wrong checkout.

6. **P2 — `pendingInspections` not set on 3 refresh paths** (`update.go` sync-done handler, `metadata_forms.go` label/metadata-edit-done handlers). These set `loading=true` and dispatched a stream refresh without recording how many `repoStatusMsg` deliveries to expect, so `handleRepoStatus` cleared `loading` after the first of N messages. Consolidated every refresh call site (F5, sync-done, reset/add/edit/repair-done, label/metadata-edit-done) through one `startStatusRefresh` helper that always sets both.

7. **P2 — ghost rows from late status messages** (`update.go` `handleRepoStatus`). A `repoStatusMsg` for a since-deleted repo (inspection still in flight from an earlier `streamStatusCmd` batch) would resurrect it via the `findRepoStatusIndex` miss → append path. Now only appends when the registry still tracks the repo (`reg.FindEntry`); otherwise the stale message is dropped.

8. **P2 — `context.Background()` instead of the model's context** (`add_action.go`, `delete_action.go`, `reset_action.go`, `repair.go`). Cancelling/quitting the TUI couldn't stop an in-flight clone/delete/reset/repair. All four Cmd constructors now take a `ctx` parameter and every call site passes `m.context()`.

9. **Dead code**: `tuiModel.syncResults` (written, never read) and `modal.go`'s `modalMoveLeft` unused `n` parameter — both removed. Confirmed unreferenced via repo-wide grep before removing.

## Deferred / needs a decision

Finding 5's root cause for the *actual delete/reset/repair engine calls* (not just the TUI's own row resolution) is that `EngineAPI.DeleteRepo/ResetRepo/RepairUpstream` take only a bare `repo_id` — there's no path/checkout parameter to disambiguate. Fixing that requires changing `internal/engine`'s concrete methods, which is out of this PR's file scope (`internal/tui/` only) and risks colliding with other in-flight PRs. I implemented the conservative option: block the action with a clear error when repo_id is ambiguous, rather than guess which checkout the engine would act on. A follow-up PR could extend `EngineAPI` (and the engine implementations) to accept a path/checkout identity for these three calls.

## Tests added

- `TestModelProgramRefVisibleAcrossValueCopies` (finding 1)
- `TestSaveLabelEditCmdDoesNotRaceWithConcurrentRegistryReads`, `TestSaveRepoMetadataEditCmdDoesNotRaceWithConcurrentRegistryReads` — fail under `-race` against the pre-fix code (finding 2)
- `TestRenderDetailViewStripsControlCharactersFromRepoMetadata`, `TestSanitizeMetadataText` (finding 3)
- `TestHandleDeleteConfirmKeyResetsOffset` (finding 4)
- `TestPrepareEditCmdResolvesRowByPathWhenRepoIDDuplicated`, `TestResolveRepairTargetUsesPathForDuplicateRepoID`, `TestStartDeleteBlocksAmbiguousRepoID`, `TestStartResetBlocksAmbiguousRepoID`, `TestStartRepairBlocksAmbiguousRepoID` (finding 5)
- `TestHandleSyncProgressKey_WhenDoneSetsPendingInspections` + extended assertions on the existing label/metadata-edit-save tests (finding 6)
- `TestHandleRepoStatusIgnoresStaleMessageForDeletedRepo`, `TestHandleRepoStatusAppendsRowStillInRegistry` (finding 7)
- `TestActionCmdsPropagateProvidedContext` (finding 8)

## Verification

```
go build ./...                                                    pass
go vet ./internal/tui/...                                         pass
go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./internal/tui/...  pass (clean)
go test ./internal/tui/...                                         pass
go test -race ./internal/tui/...                                   pass
```

All commands run with `export PATH="$GOROOT/bin:$PATH"` prepended per the working toolchain note.

## Scope

Strictly `internal/tui/` — no changes to `internal/registry` or `internal/engine`, and no `EngineAPI` signature changes, so this builds and merges independently of the sibling PR fixing `registry.backfillCheckoutID`.