### PR TITLE
feat(status): report stale remote-tracking refs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -584,6 +584,10 @@ Top-level:
         "ahead": 2,
         "behind": 0
       },
+      "remote_tracking_refs": {
+        "stale_count": 2,
+        "stale": ["origin/merged-pr", "upstream/old-topic"]
+      },
       "repair_upstream_suggestion": true,
       "submodules": { "has_submodules": true },
       "last_sync": { "ok": true, "at": "…", "error": "" }
@@ -599,6 +603,7 @@ Field notes:
 * **`primary_remote`** — preference order: `origin` > first alphabetically. Used for repo identity and tracking status.
 * **`tracking.ahead`** / **`tracking.behind`** — integer counts. Both `0` when `status` is `"equal"`. Both `null` when `status` is `"gone"` or `"none"` (no upstream to compare against).
 * **`repair_upstream_suggestion`** — optional boolean emitted on repos with `tracking.status == "gone"`, indicating that `repokeeper repair upstream` is the suggested inspection and repair path.
+* **`remote_tracking_refs`** — a read-only hygiene signal produced with `git remote prune --dry-run`. `stale_count` and `stale` describe refs a later fetch/prune would remove. When a remote cannot be queried, `inspection_error` is populated and the repository inspection continues.
 * **`apiVersion`** — identifies the schema of this JSON contract (see the stability policy below). When filtered to `diverged`, the top-level object additionally carries a `diverged` advice array; `apiVersion` is unchanged by that filter.
 
 #### JSON output schema stability policy
@@ -621,7 +626,11 @@ The `get` / `status -o json` output is a contractual surface (§"adapter contrac
     "path": "/home/user/work/org/repo",
     "action": "git fetch --all --prune",
     "outcome": "fetched",
-    "ok": true
+    "ok": true,
+    "remote_tracking_refs": {
+      "stale_count": 1,
+      "stale": ["origin/merged-pr"]
+    }
   },
   {
     "repo_id": "github.com/org/no-upstream",
@@ -639,6 +648,7 @@ Field notes:
 * **`outcome`** — the typed `OutcomeKind` (`fetched`, `rebased`, `pushed`, `skipped_no_upstream`, `skipped_missing`, `failed_fetch`, etc.). With `--dry-run` the planned variants are emitted (`planned_fetch`, `planned_push`, `planned_checkout_missing`) and **`planned`** is `true`.
 * **`ok`** — `false` only for operational failures (and `skipped_missing`); intentional skips report `ok: true` with a populated **`error`** reason. Exit-code behavior is independent of this field and unchanged by `-o json`.
 * **`error`** / **`skip_reason`** — omitted when empty.
+* **`remote_tracking_refs`** — included in dry-run plans so callers can see which refs the planned fetch/prune would remove. Detection failures are reported as `inspection_error` without turning an otherwise valid fetch plan into a failure.
 * The shape is a stable adapter surface: additive fields are non-breaking; renaming/removing a field or changing a value's meaning is a break. The DTO lives in `cmd/repokeeper` (`syncResultJSON`).
 
 ## 7. Git Operations (Engine Contract)
@@ -681,6 +691,7 @@ RepoKeeper is **Git-first**, but the architecture should stay adapter-friendly s
 * **Determine git dir:** `git rev-parse --git-dir`
 * **List all remotes:** `git remote` — enumerate all configured remotes.
 * **Remote URL (per remote):** `git remote get-url <name>` — called for each remote. Primary remote selection: prefer `origin`, fall back to first remote alphabetically.
+* **Stale remote-tracking refs (per remote):** `git remote prune --dry-run -- <name>` — queries the remote and parses only `* [would prune] <ref>` records. The dry-run does not update local refs. Remote names follow `--` to prevent option injection.
 * **Dirty state:** `git status --porcelain=v1` — **skip for bare repos** (no working tree).
 * **Current branch:** `git symbolic-ref --quiet --short HEAD` (if fails → detached) — **skip for bare repos**.
 * **Submodule presence** (no recursion):

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ RepoKeeper inventories your repositories, reports drift and broken tracking, and
 - **Sync** safely with fetch/prune-first behavior; optional `--update-local` uses `pull --rebase` under explicit conditions
 - **Registry** is stored in `.repokeeper.yaml` with staleness detection
 - **Repo-local metadata** can be read from `.repokeeper-repo.yaml` or `repokeeper.yaml` and surfaced in JSON, describe output, and the TUI detail view
+- **Remote-ref hygiene** reports stale remote-tracking refs in status, sync plans, JSON/MCP output, and the TUI without pruning them during inspection
 - **CLI-first** with tabular (`table`/`wide`) and JSON output formats
 - **Cross-platform** — macOS, Windows, Linux (incl. WSL)
 

--- a/cmd/repokeeper/status.go
+++ b/cmd/repokeeper/status.go
@@ -717,7 +717,7 @@ func writeStatusDetails(cmd *cobra.Command, repo model.RepoStatus, cwd string, r
 		return err
 	}
 	if repo.RemoteTrackingRefs.StaleCount > 0 || repo.RemoteTrackingRefs.InspectionError != "" {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "STALE_REMOTE_TRACKING_REF_COUNT: %d\n", repo.RemoteTrackingRefs.StaleCount); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "STALE_REMOTE_TRACKING_REF_COUNT: %s\n", remoteTrackingRefCountDisplay(repo.RemoteTrackingRefs)); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "STALE_REMOTE_TRACKING_REFS: %s\n", metadataListString(repo.RemoteTrackingRefs.Stale)); err != nil {

--- a/cmd/repokeeper/status.go
+++ b/cmd/repokeeper/status.go
@@ -343,9 +343,9 @@ func writeStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string
 	if showDirty {
 		headers += "\tDIRTY"
 	}
-	headers += "\tTRACKING"
+	headers += "\tTRACKING\tSTALE_REFS"
 	if wide {
-		headers = "PATH\tBRANCH\tDIRTY\tTRACKING\tPRIMARY_REMOTE\tUPSTREAM\tAHEAD\tBEHIND\tERROR_CLASS"
+		headers = "PATH\tBRANCH\tDIRTY\tTRACKING\tSTALE_REFS\tPRIMARY_REMOTE\tUPSTREAM\tAHEAD\tBEHIND\tERROR_CLASS"
 	}
 	if err := tableutil.PrintHeaders(w, noHeaders, headers); err != nil {
 		return err
@@ -373,6 +373,7 @@ func writeStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string
 			}
 		}
 		tracking := displayTrackingStatus(colorEnabled, repo.Tracking.Status)
+		staleRefs := remoteTrackingRefCountDisplay(repo.RemoteTrackingRefs)
 		if repo.Type == "mirror" {
 			tracking = termstyle.Colorize(colorEnabled, "mirror", termstyle.Info)
 		}
@@ -384,7 +385,7 @@ func writeStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string
 			if showDirty {
 				row = append(row, dirty)
 			}
-			row = append(row, tracking)
+			row = append(row, tracking, staleRefs)
 			if _, err := fmt.Fprintf(w, "%s\n", strings.Join(row, "\t")); err != nil {
 				return err
 			}
@@ -400,11 +401,12 @@ func writeStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string
 		}
 		if _, err := fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			path,
 			branch,
 			dirty,
 			tracking,
+			staleRefs,
 			repo.PrimaryRemote,
 			repo.Tracking.Upstream,
 			ahead,
@@ -415,6 +417,13 @@ func writeStatusTable(cmd *cobra.Command, report *model.StatusReport, cwd string
 		}
 	}
 	return w.Flush()
+}
+
+func remoteTrackingRefCountDisplay(status model.RemoteTrackingRefStatus) string {
+	if status.InspectionError != "" {
+		return "?"
+	}
+	return fmt.Sprintf("%d", status.StaleCount)
 }
 
 func writeRepairUpstreamHint(cmd *cobra.Command, report *model.StatusReport) error {
@@ -706,6 +715,19 @@ func writeStatusDetails(cmd *cobra.Command, repo model.RepoStatus, cwd string, r
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "UPSTREAM: %s\n", repo.Tracking.Upstream); err != nil {
 		return err
+	}
+	if repo.RemoteTrackingRefs.StaleCount > 0 || repo.RemoteTrackingRefs.InspectionError != "" {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "STALE_REMOTE_TRACKING_REF_COUNT: %d\n", repo.RemoteTrackingRefs.StaleCount); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "STALE_REMOTE_TRACKING_REFS: %s\n", metadataListString(repo.RemoteTrackingRefs.Stale)); err != nil {
+			return err
+		}
+		if repo.RemoteTrackingRefs.InspectionError != "" {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "REMOTE_TRACKING_REF_INSPECTION_ERROR: %s\n", sanitizeForDisplay(repo.RemoteTrackingRefs.InspectionError)); err != nil {
+				return err
+			}
+		}
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "LABELS: %s\n", metadataMapString(repo.Labels)); err != nil {
 		return err

--- a/cmd/repokeeper/status_characterization_test.go
+++ b/cmd/repokeeper/status_characterization_test.go
@@ -171,6 +171,19 @@ var _ = Describe("writeStatusDetails", func() {
 			Expect(out.String()).To(ContainSubstring("STALE_REMOTE_TRACKING_REF_COUNT: 2\n"))
 			Expect(out.String()).To(ContainSubstring("STALE_REMOTE_TRACKING_REFS: origin/merged,upstream/old\n"))
 		})
+
+		It("renders an unknown marker instead of a real zero when inspection failed", func() {
+			repo := model.RepoStatus{
+				Path: "/repos/testrepo",
+				RemoteTrackingRefs: model.RemoteTrackingRefStatus{
+					InspectionError: "network unavailable",
+				},
+			}
+			Expect(writeStatusDetails(cmd, repo, "/repos", nil)).To(Succeed())
+			Expect(out.String()).To(ContainSubstring("STALE_REMOTE_TRACKING_REF_COUNT: ?\n"))
+			Expect(out.String()).NotTo(ContainSubstring("STALE_REMOTE_TRACKING_REF_COUNT: 0\n"))
+			Expect(out.String()).To(ContainSubstring("REMOTE_TRACKING_REF_INSPECTION_ERROR: network unavailable\n"))
+		})
 	})
 
 	Context("full repo snapshot — all fields populated", func() {

--- a/cmd/repokeeper/status_characterization_test.go
+++ b/cmd/repokeeper/status_characterization_test.go
@@ -158,6 +158,21 @@ var _ = Describe("writeStatusDetails", func() {
 		})
 	})
 
+	Context("stale remote-tracking refs", func() {
+		It("prints the count and ref names", func() {
+			repo := model.RepoStatus{
+				Path: "/repos/testrepo",
+				RemoteTrackingRefs: model.RemoteTrackingRefStatus{
+					StaleCount: 2,
+					Stale:      []string{"origin/merged", "upstream/old"},
+				},
+			}
+			Expect(writeStatusDetails(cmd, repo, "/repos", nil)).To(Succeed())
+			Expect(out.String()).To(ContainSubstring("STALE_REMOTE_TRACKING_REF_COUNT: 2\n"))
+			Expect(out.String()).To(ContainSubstring("STALE_REMOTE_TRACKING_REFS: origin/merged,upstream/old\n"))
+		})
+	})
+
 	Context("full repo snapshot — all fields populated", func() {
 		It("matches complete expected output exactly", func() {
 			repo := model.RepoStatus{

--- a/cmd/repokeeper/status_helpers_test.go
+++ b/cmd/repokeeper/status_helpers_test.go
@@ -316,7 +316,7 @@ func TestStatusJSONOutputFlagsGoneRepairSuggestion(t *testing.T) {
 	report := &model.StatusReport{
 		GeneratedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
 		Repos: []model.RepoStatus{
-			{RepoID: "github.com/org/gone", Path: "/repos/gone", Tracking: model.Tracking{Status: model.TrackingGone}},
+			{RepoID: "github.com/org/gone", Path: "/repos/gone", Tracking: model.Tracking{Status: model.TrackingGone}, RemoteTrackingRefs: model.RemoteTrackingRefStatus{StaleCount: 1, Stale: []string{"origin/merged"}}},
 			{RepoID: "github.com/org/clean", Path: "/repos/clean", Tracking: model.Tracking{Status: model.TrackingEqual}},
 		},
 	}
@@ -327,8 +327,9 @@ func TestStatusJSONOutputFlagsGoneRepairSuggestion(t *testing.T) {
 	}
 	var doc struct {
 		Repos []struct {
-			RepoID                   string `json:"repo_id"`
-			RepairUpstreamSuggestion bool   `json:"repair_upstream_suggestion"`
+			RepoID                   string                        `json:"repo_id"`
+			RepairUpstreamSuggestion bool                          `json:"repair_upstream_suggestion"`
+			RemoteTrackingRefs       model.RemoteTrackingRefStatus `json:"remote_tracking_refs"`
 		} `json:"repos"`
 	}
 	if err := json.Unmarshal(raw, &doc); err != nil {
@@ -339,6 +340,9 @@ func TestStatusJSONOutputFlagsGoneRepairSuggestion(t *testing.T) {
 	}
 	if !doc.Repos[0].RepairUpstreamSuggestion {
 		t.Fatalf("expected gone repo to carry repair_upstream_suggestion: %s", raw)
+	}
+	if doc.Repos[0].RemoteTrackingRefs.StaleCount != 1 || len(doc.Repos[0].RemoteTrackingRefs.Stale) != 1 {
+		t.Fatalf("expected machine-readable stale ref status: %s", raw)
 	}
 	if doc.Repos[1].RepairUpstreamSuggestion {
 		t.Fatalf("did not expect clean repo to carry repair_upstream_suggestion: %s", raw)

--- a/cmd/repokeeper/sync.go
+++ b/cmd/repokeeper/sync.go
@@ -243,14 +243,15 @@ func init() {
 // MCP consumers parse the same fields. Adding a field is non-breaking; renaming
 // or removing one, or changing a value's meaning, is a contract break.
 type syncResultJSON struct {
-	RepoID     string `json:"repo_id"`
-	Path       string `json:"path"`
-	Action     string `json:"action"`
-	Outcome    string `json:"outcome"`
-	OK         bool   `json:"ok"`
-	Planned    bool   `json:"planned,omitempty"`
-	Error      string `json:"error,omitempty"`
-	SkipReason string `json:"skip_reason,omitempty"`
+	RepoID             string                        `json:"repo_id"`
+	Path               string                        `json:"path"`
+	Action             string                        `json:"action"`
+	Outcome            string                        `json:"outcome"`
+	OK                 bool                          `json:"ok"`
+	Planned            bool                          `json:"planned,omitempty"`
+	Error              string                        `json:"error,omitempty"`
+	SkipReason         string                        `json:"skip_reason,omitempty"`
+	RemoteTrackingRefs model.RemoteTrackingRefStatus `json:"remote_tracking_refs"`
 }
 
 func toSyncResultJSON(res engine.SyncResult) syncResultJSON {
@@ -269,14 +270,15 @@ func toSyncResultJSON(res engine.SyncResult) syncResultJSON {
 	}
 
 	return syncResultJSON{
-		RepoID:     res.RepoID,
-		Path:       res.Path,
-		Action:     res.Action,
-		Outcome:    string(res.Outcome),
-		OK:         res.OK,
-		Planned:    planned,
-		Error:      errText,
-		SkipReason: res.SkipReason,
+		RepoID:             res.RepoID,
+		Path:               res.Path,
+		Action:             res.Action,
+		Outcome:            string(res.Outcome),
+		OK:                 res.OK,
+		Planned:            planned,
+		Error:              errText,
+		SkipReason:         res.SkipReason,
+		RemoteTrackingRefs: res.RemoteTrackingRefs,
 	}
 }
 
@@ -556,7 +558,7 @@ func syncTableModeFor(cmd *cobra.Command, wide bool) syncTableMode {
 }
 
 func syncTableHeaders(mode syncTableMode, wide bool) string {
-	headers := "PATH\tACTION\tBRANCH\tDIRTY\tTRACKING\tOK\tERROR_CLASS\tERROR\tREPO"
+	headers := "PATH\tACTION\tBRANCH\tDIRTY\tTRACKING\tSTALE_REFS\tOK\tERROR_CLASS\tERROR\tREPO"
 	if mode == syncTableModeCompact {
 		headers = "PATH\tACTION\tOK\tERROR\tREPO"
 	}
@@ -646,12 +648,13 @@ func writeSyncTable(cmd *cobra.Command, results []engine.SyncResult, report *mod
 				continue
 			default:
 			}
-			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				path,
 				action,
 				branch,
 				dirty,
 				tracking,
+				remoteTrackingRefCountDisplay(res.RemoteTrackingRefs),
 				ok,
 				res.ErrorClass,
 				formatCell(res.Error, wrap, 36),
@@ -675,12 +678,13 @@ func writeSyncTable(cmd *cobra.Command, results []engine.SyncResult, report *mod
 			primaryRemote = repo.PrimaryRemote
 			upstream = repo.Tracking.Upstream
 		}
-		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			path,
 			action,
 			branch,
 			dirty,
 			tracking,
+			remoteTrackingRefCountDisplay(res.RemoteTrackingRefs),
 			ok,
 			res.ErrorClass,
 			formatCell(res.Error, wrap, 36),

--- a/cmd/repokeeper/sync_json_test.go
+++ b/cmd/repokeeper/sync_json_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/skaphos/repokeeper/internal/engine"
+	"github.com/skaphos/repokeeper/internal/model"
 )
 
 // These specs lock the stable `reconcile` / `sync -o json` contract (SKA-207):
@@ -88,6 +89,24 @@ var _ = Describe("sync -o json result shape", func() {
 		Expect(obj).To(HaveKeyWithValue("planned", true))
 		Expect(obj).To(HaveKeyWithValue("outcome", "planned_fetch"))
 		Expect(obj).NotTo(HaveKey("error"))
+	})
+
+	It("includes machine-readable stale remote-tracking refs", func() {
+		obj := marshalOne(engine.SyncResult{
+			RepoID:  "github.com/org/repo",
+			Path:    "/work/org/repo",
+			Outcome: engine.SyncOutcomePlannedFetch,
+			OK:      true,
+			RemoteTrackingRefs: model.RemoteTrackingRefStatus{
+				StaleCount: 2,
+				Stale:      []string{"origin/one", "origin/two"},
+			},
+		})
+
+		refs, ok := obj["remote_tracking_refs"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(refs).To(HaveKeyWithValue("stale_count", BeNumerically("==", 2)))
+		Expect(refs["stale"]).To(ConsistOf("origin/one", "origin/two"))
 	})
 
 	It("does not report executed results as planned", func() {

--- a/cmd/repokeeper/terminal_width_test.go
+++ b/cmd/repokeeper/terminal_width_test.go
@@ -368,10 +368,10 @@ func TestStatusTableHeaderSnapshotsAcrossWidths(t *testing.T) {
 		width      int
 		wantHeader string
 	}{
-		{width: 80, wantHeader: "PATH|BRANCH|TRACKING"},
-		{width: 100, wantHeader: "PATH|BRANCH|DIRTY|TRACKING"},
-		{width: 120, wantHeader: "PATH|BRANCH|DIRTY|TRACKING"},
-		{width: 160, wantHeader: "PATH|BRANCH|DIRTY|TRACKING"},
+		{width: 80, wantHeader: "PATH|BRANCH|TRACKING|STALE_REFS"},
+		{width: 100, wantHeader: "PATH|BRANCH|DIRTY|TRACKING|STALE_REFS"},
+		{width: 120, wantHeader: "PATH|BRANCH|DIRTY|TRACKING|STALE_REFS"},
+		{width: 160, wantHeader: "PATH|BRANCH|DIRTY|TRACKING|STALE_REFS"},
 	}
 
 	for _, tc := range cases {
@@ -391,9 +391,9 @@ func TestSyncTableHeaderSnapshotsAcrossWidths(t *testing.T) {
 		wantHeader string
 	}{
 		{width: 80, wantHeader: "PATH|ACTION|OK|ERROR|REPO"},
-		{width: 100, wantHeader: "PATH|ACTION|BRANCH|DIRTY|TRACKING|OK|ERROR_CLASS|ERROR|REPO"},
-		{width: 120, wantHeader: "PATH|ACTION|BRANCH|DIRTY|TRACKING|OK|ERROR_CLASS|ERROR|REPO"},
-		{width: 160, wantHeader: "PATH|ACTION|BRANCH|DIRTY|TRACKING|OK|ERROR_CLASS|ERROR|REPO"},
+		{width: 100, wantHeader: "PATH|ACTION|BRANCH|DIRTY|TRACKING|STALE_REFS|OK|ERROR_CLASS|ERROR|REPO"},
+		{width: 120, wantHeader: "PATH|ACTION|BRANCH|DIRTY|TRACKING|STALE_REFS|OK|ERROR_CLASS|ERROR|REPO"},
+		{width: 160, wantHeader: "PATH|ACTION|BRANCH|DIRTY|TRACKING|STALE_REFS|OK|ERROR_CLASS|ERROR|REPO"},
 	}
 
 	for _, tc := range cases {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,7 @@ This is the canonical command reference for RepoKeeper. Keep this file in sync w
 - Supports `--only`, `--field-selector`, and label selector `-l, --selector`.
 - Label selector supports `key` and `key=value`, comma-separated AND.
 - Use `-o wide` for additional `PRIMARY_REMOTE`, `UPSTREAM`, `AHEAD`, `BEHIND`, and `ERROR_CLASS`.
+- Table output includes `STALE_REFS`, the number of remote-tracking refs a prune would remove. JSON and `describe` include the ref names and any non-fatal remote inspection error.
 - JSON output includes repo-local metadata when `.repokeeper-repo.yaml` or `repokeeper.yaml` is present.
 
 ### `repokeeper describe`
@@ -71,6 +72,7 @@ This is the canonical command reference for RepoKeeper. Keep this file in sync w
 ### `repokeeper reconcile`
 
 - Shows a preflight plan before execution.
+- Dry-run plans include stale remote-tracking ref count/list data for the fetch/prune step.
 - Sync is fetch/prune-first; `--update-local` is the explicit path for local branch update behavior.
 - Prompts only when mutating actions are planned (rebase/stash/checkout-missing clone), unless `--yes`.
 - Supports `--checkout-missing` to clone entries marked missing.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -118,6 +118,7 @@ CLI and TUI remain the preferred operator interfaces for execution-heavy workflo
 Argument notes:
 
 - `plan_sync` remains side-effect-free even when it previews local update candidates.
+- `plan_sync` entries include `remote_tracking_refs` with `stale_count`, the stale ref list, and a non-fatal `inspection_error` when a remote cannot be queried.
 - `scan_workspace.roots` is a string array of absolute or otherwise valid filesystem roots.
 - If `scan_workspace.roots` is omitted, RepoKeeper falls back to the effective workspace root resolved from the active config path.
 - `set_labels.set` is an object whose values must be strings.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -461,6 +461,8 @@ type SyncResult struct {
 	Planned bool
 	// SkipReason carries typed skip rationale for outcomes that intentionally skip work.
 	SkipReason string
+	// RemoteTrackingRefs describes refs that the planned fetch would prune.
+	RemoteTrackingRefs model.RemoteTrackingRefStatus
 	// steps is the ordered list of typed VCS operations an executor performs for
 	// this planned item. Execution dispatches on these steps rather than parsing
 	// the human-readable Action string, so non-git backends and skip-with-fetch
@@ -1101,13 +1103,21 @@ func (e *Engine) runSyncEntry(ctx context.Context, entry registry.Entry, opts Sy
 
 func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts SyncOptions) SyncResult {
 	fetchAction := syncFetchAction(ctx, e.adapter, entry.Path)
+	remoteTrackingRefs := model.RemoteTrackingRefStatus{}
+	if !opts.UpdateLocal {
+		remoteTrackingRefs = e.inspectRemoteTrackingRefs(ctx, entry.Path, nil)
+	}
+	withRemoteTrackingRefs := func(result SyncResult) SyncResult {
+		result.RemoteTrackingRefs = remoteTrackingRefs
+		return result
+	}
 
 	// skippedLocalUpdate builds a plan that still fetches but intentionally skips
 	// the local update. The fetch step is retained (and Planned=true) so that
 	// --update-local never fetches fewer repos than a plain sync, while the
 	// reported outcome preserves the typed skip reason.
 	skippedLocalUpdate := func(reason string) SyncResult {
-		return SyncResult{
+		return withRemoteTrackingRefs(SyncResult{
 			RepoID:     entry.RepoID,
 			Path:       entry.Path,
 			Outcome:    SyncOutcomeSkippedLocalUpdate,
@@ -1118,11 +1128,11 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 			SkipReason: reason,
 			Planned:    true,
 			steps:      []syncStep{syncStepFetch},
-		}
+		})
 	}
 
 	if !opts.UpdateLocal {
-		return SyncResult{
+		return withRemoteTrackingRefs(SyncResult{
 			RepoID:  entry.RepoID,
 			Path:    entry.Path,
 			Outcome: SyncOutcomePlannedFetch,
@@ -1131,7 +1141,7 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 			Action:  fetchAction,
 			Planned: true,
 			steps:   []syncStep{syncStepFetch},
-		}
+		})
 	}
 
 	supported, reason, err := supportsLocalUpdate(ctx, e.adapter, entry.Path)
@@ -1147,8 +1157,9 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 	if err != nil {
 		return inspectFailureResult(entry, err, e.classifier)
 	}
+	remoteTrackingRefs = status.RemoteTrackingRefs
 	if opts.PushLocal && status.Tracking.Status == model.TrackingAhead {
-		return SyncResult{
+		return withRemoteTrackingRefs(SyncResult{
 			RepoID:  entry.RepoID,
 			Path:    entry.Path,
 			Outcome: SyncOutcomePlannedPush,
@@ -1157,7 +1168,7 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 			Action:  fetchAction + " && git push",
 			Planned: true,
 			steps:   []syncStep{syncStepFetch, syncStepPush},
-		}
+		})
 	}
 	if reason := pullRebaseSkipReason(status, PullRebasePolicyOptions{
 		RebaseDirty:          opts.RebaseDirty,
@@ -1185,7 +1196,7 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 		steps = append(steps, syncStepStashPop)
 		action += " && git stash pop"
 	}
-	return SyncResult{
+	return withRemoteTrackingRefs(SyncResult{
 		RepoID:  entry.RepoID,
 		Path:    entry.Path,
 		Outcome: SyncOutcomePlannedFetch,
@@ -1194,7 +1205,7 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 		Action:  action,
 		Planned: true,
 		steps:   steps,
-	}
+	})
 }
 
 func (e *Engine) runSyncApply(ctx context.Context, entry registry.Entry, opts SyncOptions) SyncResult {
@@ -1446,6 +1457,7 @@ func (e *Engine) inspectRepoCore(ctx context.Context, path string) (*model.RepoS
 	for _, r := range remotes {
 		remoteNames = append(remoteNames, r.Name)
 	}
+	remoteTrackingRefs := e.inspectRemoteTrackingRefs(ctx, path, remoteNames)
 	primary := e.adapter.PrimaryRemote(remoteNames)
 	var remoteURL string
 	for _, r := range remotes {
@@ -1483,17 +1495,43 @@ func (e *Engine) inspectRepoCore(ctx context.Context, path string) (*model.RepoS
 	}
 
 	status := &model.RepoStatus{
-		RepoID:        repoID,
-		Path:          path,
-		Bare:          bare,
-		Remotes:       remotes,
-		PrimaryRemote: primary,
-		Head:          head,
-		Worktree:      worktree,
-		Tracking:      tracking,
-		Submodules:    model.Submodules{HasSubmodules: hasSubmodules},
+		RepoID:             repoID,
+		Path:               path,
+		Bare:               bare,
+		Remotes:            remotes,
+		PrimaryRemote:      primary,
+		Head:               head,
+		Worktree:           worktree,
+		Tracking:           tracking,
+		Submodules:         model.Submodules{HasSubmodules: hasSubmodules},
+		RemoteTrackingRefs: remoteTrackingRefs,
 	}
 	return status, nil
+}
+
+func (e *Engine) inspectRemoteTrackingRefs(ctx context.Context, path string, remoteNames []string) model.RemoteTrackingRefStatus {
+	inspector, ok := e.adapter.(vcs.RemoteTrackingRefInspector)
+	if !ok {
+		return model.RemoteTrackingRefStatus{}
+	}
+	if remoteNames == nil {
+		remotes, err := e.adapter.Remotes(ctx, path)
+		if err != nil {
+			return model.RemoteTrackingRefStatus{InspectionError: err.Error()}
+		}
+		remoteNames = make([]string, 0, len(remotes))
+		for _, remote := range remotes {
+			remoteNames = append(remoteNames, remote.Name)
+		}
+	}
+	refs, err := inspector.StaleRemoteTrackingRefs(ctx, path, remoteNames)
+	if err != nil {
+		if e.logger != nil {
+			e.logger.Warnf("stale remote-tracking ref inspection failed for %s: %v", path, err)
+		}
+		return model.RemoteTrackingRefStatus{InspectionError: err.Error()}
+	}
+	return model.RemoteTrackingRefStatus{StaleCount: len(refs), Stale: refs}
 }
 
 func (e *Engine) upsertRegistryEntry(entry registry.Entry) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -844,7 +844,7 @@ func (e *Engine) Sync(ctx context.Context, opts SyncOptions) ([]SyncResult, erro
 	results := make([]SyncResult, 0, len(entries))
 
 	for _, entry := range entries {
-		queue, immediate := e.prepareSyncEntry(ctx, entry, opts, timeoutSeconds)
+		queue, cached, immediate := e.prepareSyncEntry(ctx, entry, opts, timeoutSeconds)
 		if immediate != nil {
 			results = append(results, *immediate)
 		}
@@ -853,11 +853,11 @@ func (e *Engine) Sync(ctx context.Context, opts SyncOptions) ([]SyncResult, erro
 		}
 		sem <- struct{}{}
 		spawned++
-		go func(entry registry.Entry) {
-			res := e.runSyncEntry(ctx, entry, opts, timeoutSeconds)
+		go func(entry registry.Entry, cached *model.RepoStatus) {
+			res := e.runSyncEntry(ctx, entry, opts, timeoutSeconds, cached)
 			<-sem
 			out <- res
-		}(entry)
+		}(entry, cached)
 	}
 
 	for i := 0; i < spawned; i++ {
@@ -912,7 +912,7 @@ func (e *Engine) syncSequentialStopOnError(ctx context.Context, opts SyncOptions
 	_, timeoutSeconds := e.syncRuntime(opts)
 	results := make([]SyncResult, 0, len(entries))
 	for _, entry := range entries {
-		queue, immediate := e.prepareSyncEntry(ctx, entry, opts, timeoutSeconds)
+		queue, cached, immediate := e.prepareSyncEntry(ctx, entry, opts, timeoutSeconds)
 		if immediate != nil {
 			results = append(results, *immediate)
 			if !immediate.OK {
@@ -923,7 +923,7 @@ func (e *Engine) syncSequentialStopOnError(ctx context.Context, opts SyncOptions
 		if !queue {
 			continue
 		}
-		res := e.runSyncEntry(ctx, entry, opts, timeoutSeconds)
+		res := e.runSyncEntry(ctx, entry, opts, timeoutSeconds, cached)
 		e.logSyncFailureHint(res)
 		results = append(results, res)
 		if !res.OK {
@@ -935,16 +935,20 @@ func (e *Engine) syncSequentialStopOnError(ctx context.Context, opts SyncOptions
 	return results, nil
 }
 
-func (e *Engine) prepareSyncEntry(ctx context.Context, entry registry.Entry, opts SyncOptions, timeoutSeconds int) (bool, *SyncResult) {
+// prepareSyncEntry decides whether entry should be queued for sync work. When an
+// inspect-based filter forces a live inspection it returns that *model.RepoStatus
+// (otherwise nil) so runSyncEntry can reuse it instead of inspecting the repo a
+// second time.
+func (e *Engine) prepareSyncEntry(ctx context.Context, entry registry.Entry, opts SyncOptions, timeoutSeconds int) (bool, *model.RepoStatus, *SyncResult) {
 	if opts.Filter == FilterMissing && entry.Status != registry.StatusMissing {
-		return false, nil
+		return false, nil, nil
 	}
 	if entry.Status == registry.StatusMissing {
 		res := e.handleMissingSyncEntry(ctx, entry, opts)
-		return false, &res
+		return false, nil, &res
 	}
 	if opts.Filter == FilterGone && entry.Status != registry.StatusPresent {
-		return false, nil
+		return false, nil, nil
 	}
 	inspectCtx := ctx
 	if timeoutSeconds > 0 {
@@ -952,12 +956,12 @@ func (e *Engine) prepareSyncEntry(ctx context.Context, entry registry.Entry, opt
 		inspectCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 		defer cancel()
 	}
-	matches, inspectFailure := e.syncEntryMatchesInspectFilter(inspectCtx, entry, opts)
+	matches, inspected, inspectFailure := e.syncEntryMatchesInspectFilter(inspectCtx, entry, opts)
 	if inspectFailure != nil {
-		return false, inspectFailure
+		return false, nil, inspectFailure
 	}
 	if !matches {
-		return false, nil
+		return false, nil, nil
 	}
 	if strings.TrimSpace(entry.RemoteURL) == "" {
 		res := SyncResult{
@@ -968,47 +972,51 @@ func (e *Engine) prepareSyncEntry(ctx context.Context, entry registry.Entry, opt
 			ErrorClass: "skipped",
 			Error:      SyncErrorSkippedNoUpstream,
 		}
-		return false, &res
+		return false, nil, &res
 	}
-	return true, nil
+	return true, inspected, nil
 }
 
-func (e *Engine) syncEntryMatchesInspectFilter(ctx context.Context, entry registry.Entry, opts SyncOptions) (bool, *SyncResult) {
+// syncEntryMatchesInspectFilter reports whether entry matches opts.Filter. For
+// inspect-based filters it returns the *model.RepoStatus it inspected so callers
+// can reuse it (e.g. to avoid a second `git remote prune --dry-run` round during
+// planning); the status is nil for non-inspect filters and on inspect failure.
+func (e *Engine) syncEntryMatchesInspectFilter(ctx context.Context, entry registry.Entry, opts SyncOptions) (bool, *model.RepoStatus, *SyncResult) {
 	if !filterRequiresInspect(opts.Filter) {
 		// Non-inspect filters (all/errors/missing) match without a live inspect,
 		// but an unknown filter must fail closed rather than matching every repo.
 		if !isKnownFilterKind(opts.Filter) {
-			return false, nil
+			return false, nil, nil
 		}
-		return true, nil
+		return true, nil, nil
 	}
 	status, err := e.InspectRepo(ctx, entry.Path)
 	if err != nil {
 		failure := inspectFailureResult(entry, err, e.classifier)
-		return false, &failure
+		return false, nil, &failure
 	}
 	switch opts.Filter {
 	case FilterDirty:
-		return status.Worktree != nil && status.Worktree.Dirty, nil
+		return status.Worktree != nil && status.Worktree.Dirty, status, nil
 	case FilterClean:
 		// Aligned with filterStatus: a repo with no worktree (e.g. bare) is not
 		// reported as clean, so both filter paths agree on the same repo set.
-		return status.Worktree != nil && !status.Worktree.Dirty, nil
+		return status.Worktree != nil && !status.Worktree.Dirty, status, nil
 	case FilterGone:
-		return status.Tracking.Status == model.TrackingGone, nil
+		return status.Tracking.Status == model.TrackingGone, status, nil
 	case FilterDiverged:
-		return status.Tracking.Status == model.TrackingDiverged, nil
+		return status.Tracking.Status == model.TrackingDiverged, status, nil
 	case FilterBehind:
-		return status.Tracking.Status == model.TrackingBehind, nil
+		return status.Tracking.Status == model.TrackingBehind, status, nil
 	case FilterAhead:
-		return status.Tracking.Status == model.TrackingAhead, nil
+		return status.Tracking.Status == model.TrackingAhead, status, nil
 	case FilterEqual:
-		return status.Tracking.Status == model.TrackingEqual, nil
+		return status.Tracking.Status == model.TrackingEqual, status, nil
 	case FilterRemoteMismatch:
-		return hasRemoteMismatch(*status, entry, e.normalizer), nil
+		return hasRemoteMismatch(*status, entry, e.normalizer), status, nil
 	default:
 		// Fail closed: an unknown inspect filter must not match every repo.
-		return false, nil
+		return false, status, nil
 	}
 }
 
@@ -1088,7 +1096,10 @@ func (e *Engine) handleMissingSyncEntry(ctx context.Context, entry registry.Entr
 	return SyncResult{RepoID: entry.RepoID, Path: entry.Path, Outcome: SyncOutcomeCheckoutMissing, OK: true, Action: action}
 }
 
-func (e *Engine) runSyncEntry(ctx context.Context, entry registry.Entry, opts SyncOptions, timeoutSeconds int) SyncResult {
+// runSyncEntry executes (or plans) sync work for entry. cached carries the
+// inspection prepareSyncEntry already performed for inspect-based filters, or nil;
+// downstream paths reuse it instead of inspecting the same repo again.
+func (e *Engine) runSyncEntry(ctx context.Context, entry registry.Entry, opts SyncOptions, timeoutSeconds int, cached *model.RepoStatus) SyncResult {
 	repoCtx := ctx
 	if timeoutSeconds > 0 {
 		var cancel context.CancelFunc
@@ -1096,16 +1107,22 @@ func (e *Engine) runSyncEntry(ctx context.Context, entry registry.Entry, opts Sy
 		defer cancel()
 	}
 	if opts.DryRun {
-		return e.runSyncDryRun(repoCtx, entry, opts)
+		return e.runSyncDryRun(repoCtx, entry, opts, cached)
 	}
-	return e.runSyncApply(repoCtx, entry, opts)
+	return e.runSyncApply(repoCtx, entry, opts, cached)
 }
 
-func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts SyncOptions) SyncResult {
+func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts SyncOptions, cached *model.RepoStatus) SyncResult {
 	fetchAction := syncFetchAction(ctx, e.adapter, entry.Path)
 	remoteTrackingRefs := model.RemoteTrackingRefStatus{}
 	if !opts.UpdateLocal {
-		remoteTrackingRefs = e.inspectRemoteTrackingRefs(ctx, entry.Path, nil)
+		// Reuse the inspection an inspect-based filter already ran for this repo
+		// rather than issuing a second `git remote prune --dry-run` round.
+		if cached != nil {
+			remoteTrackingRefs = cached.RemoteTrackingRefs
+		} else {
+			remoteTrackingRefs = e.inspectRemoteTrackingRefs(ctx, entry.Path, nil)
+		}
 	}
 	withRemoteTrackingRefs := func(result SyncResult) SyncResult {
 		result.RemoteTrackingRefs = remoteTrackingRefs
@@ -1152,10 +1169,15 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 		return skippedLocalUpdate(reason)
 	}
 	// We still inspect during dry-run so skip reasons and planned actions
-	// match live execution as closely as possible.
-	status, err := e.InspectRepo(ctx, entry.Path)
-	if err != nil {
-		return inspectFailureResult(entry, err, e.classifier)
+	// match live execution as closely as possible, reusing an inspect-based
+	// filter's earlier inspection when one is available.
+	status := cached
+	if status == nil {
+		var err error
+		status, err = e.InspectRepo(ctx, entry.Path)
+		if err != nil {
+			return inspectFailureResult(entry, err, e.classifier)
+		}
 	}
 	remoteTrackingRefs = status.RemoteTrackingRefs
 	if opts.PushLocal && status.Tracking.Status == model.TrackingAhead {
@@ -1208,11 +1230,17 @@ func (e *Engine) runSyncDryRun(ctx context.Context, entry registry.Entry, opts S
 	})
 }
 
-func (e *Engine) runSyncApply(ctx context.Context, entry registry.Entry, opts SyncOptions) SyncResult {
+func (e *Engine) runSyncApply(ctx context.Context, entry registry.Entry, opts SyncOptions, cached *model.RepoStatus) SyncResult {
 	if opts.Filter == FilterGone {
-		status, err := e.InspectRepo(ctx, entry.Path)
-		if err != nil {
-			return inspectFailureResult(entry, err, e.classifier)
+		// The gone filter already inspected this repo during prepareSyncEntry;
+		// reuse that result instead of inspecting a second time.
+		status := cached
+		if status == nil {
+			var err error
+			status, err = e.InspectRepo(ctx, entry.Path)
+			if err != nil {
+				return inspectFailureResult(entry, err, e.classifier)
+			}
 		}
 		if status.Tracking.Status != model.TrackingGone {
 			return SyncResult{RepoID: entry.RepoID, Path: entry.Path, Outcome: SyncOutcomeSkipped, OK: true, Error: SyncErrorSkipped}

--- a/internal/engine/engine_internal_test.go
+++ b/internal/engine/engine_internal_test.go
@@ -279,26 +279,26 @@ func TestPrepareSyncEntryBranches(t *testing.T) {
 		Status:    registry.StatusPresent,
 	}
 
-	queue, immediate := eng.prepareSyncEntry(context.Background(), present, SyncOptions{}, 0)
+	queue, _, immediate := eng.prepareSyncEntry(context.Background(), present, SyncOptions{}, 0)
 	if !queue || immediate != nil {
 		t.Fatalf("expected queued present repo, got queue=%v immediate=%+v", queue, immediate)
 	}
 
-	queue, immediate = eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterMissing}, 0)
+	queue, _, immediate = eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterMissing}, 0)
 	if queue || immediate != nil {
 		t.Fatalf("expected missing-filter skip, got queue=%v immediate=%+v", queue, immediate)
 	}
 
 	missing := present
 	missing.Status = registry.StatusMissing
-	queue, immediate = eng.prepareSyncEntry(context.Background(), missing, SyncOptions{CheckoutMissing: false}, 0)
+	queue, _, immediate = eng.prepareSyncEntry(context.Background(), missing, SyncOptions{CheckoutMissing: false}, 0)
 	if queue || immediate == nil || immediate.Error != SyncErrorMissing {
 		t.Fatalf("expected missing immediate result, got queue=%v immediate=%+v", queue, immediate)
 	}
 
 	noUpstream := present
 	noUpstream.RemoteURL = ""
-	queue, immediate = eng.prepareSyncEntry(context.Background(), noUpstream, SyncOptions{}, 0)
+	queue, _, immediate = eng.prepareSyncEntry(context.Background(), noUpstream, SyncOptions{}, 0)
 	if queue || immediate == nil || immediate.Error != SyncErrorSkippedNoUpstream || !immediate.OK {
 		t.Fatalf("expected skipped_no_upstream immediate result, got queue=%v immediate=%+v", queue, immediate)
 	}
@@ -312,7 +312,7 @@ func TestSyncEntryMatchesInspectFilterFailure(t *testing.T) {
 	eng := New(&config.Config{}, &registry.Registry{}, vcs.NewGitAdapter(runner), nil, nil, nil)
 	entry := registry.Entry{RepoID: "repo", Path: "/repo", Status: registry.StatusPresent}
 
-	match, failure := eng.syncEntryMatchesInspectFilter(context.Background(), entry, SyncOptions{Filter: FilterDirty})
+	match, _, failure := eng.syncEntryMatchesInspectFilter(context.Background(), entry, SyncOptions{Filter: FilterDirty})
 	if match || failure == nil {
 		t.Fatalf("expected inspect failure, got match=%v failure=%+v", match, failure)
 	}
@@ -388,7 +388,7 @@ func TestRunSyncDryRunAndApplyHelpers(t *testing.T) {
 	eng := New(&config.Config{}, &registry.Registry{}, vcs.NewGitAdapter(runner), nil, nil, nil)
 	entry := registry.Entry{RepoID: "repo", Path: "/repo", RemoteURL: "git@github.com:org/repo.git", Status: registry.StatusPresent}
 
-	dry := eng.runSyncDryRun(context.Background(), entry, SyncOptions{UpdateLocal: true, PushLocal: true})
+	dry := eng.runSyncDryRun(context.Background(), entry, SyncOptions{UpdateLocal: true, PushLocal: true}, nil)
 	if dry.Outcome != "planned_push" || dry.Error != SyncErrorDryRun || !strings.Contains(dry.Action, "git push") {
 		t.Fatalf("unexpected dry-run push plan: %+v", dry)
 	}
@@ -396,7 +396,7 @@ func TestRunSyncDryRunAndApplyHelpers(t *testing.T) {
 		t.Fatalf("expected dry-run push plan to set Planned=true: %+v", dry)
 	}
 
-	applied := eng.runSyncApply(context.Background(), entry, SyncOptions{UpdateLocal: false})
+	applied := eng.runSyncApply(context.Background(), entry, SyncOptions{UpdateLocal: false}, nil)
 	if !applied.OK || applied.Outcome != "fetched" {
 		t.Fatalf("unexpected apply fetch result: %+v", applied)
 	}
@@ -643,7 +643,7 @@ func TestRunSyncHelperEdgeBranches(t *testing.T) {
 		"/repo:remote":                         {err: errors.New("permission denied")},
 	}}
 	eng := New(&config.Config{}, &registry.Registry{}, vcs.NewGitAdapter(inspectFailRunner), nil, nil, nil)
-	dry := eng.runSyncDryRun(context.Background(), entry, SyncOptions{UpdateLocal: true})
+	dry := eng.runSyncDryRun(context.Background(), entry, SyncOptions{UpdateLocal: true}, nil)
 	if dry.Outcome != "failed_inspect" || dry.ErrorClass != "auth" {
 		t.Fatalf("expected inspect failure dry-run result, got %+v", dry)
 	}
@@ -661,7 +661,7 @@ func TestRunSyncHelperEdgeBranches(t *testing.T) {
 		"/repo:config --file .gitmodules --get-regexp submodule": {err: errors.New("none")},
 	}}
 	eng = New(&config.Config{}, &registry.Registry{}, vcs.NewGitAdapter(filterGoneRunner), nil, nil, nil)
-	gone := eng.runSyncApply(context.Background(), entry, SyncOptions{Filter: FilterGone})
+	gone := eng.runSyncApply(context.Background(), entry, SyncOptions{Filter: FilterGone}, nil)
 	if !gone.OK || gone.Outcome != "skipped" || gone.Error != SyncErrorSkipped {
 		t.Fatalf("expected filter-gone skip result, got %+v", gone)
 	}
@@ -691,7 +691,7 @@ func TestSyncSkipsUnsupportedLocalUpdateByAdapterCapability(t *testing.T) {
 	}
 	entry := registry.Entry{RepoID: "repo", Path: "/repo", Status: registry.StatusPresent}
 
-	dry := eng.runSyncDryRun(context.Background(), entry, SyncOptions{UpdateLocal: true})
+	dry := eng.runSyncDryRun(context.Background(), entry, SyncOptions{UpdateLocal: true}, nil)
 	if dry.Outcome != SyncOutcomeSkippedLocalUpdate || !dry.OK {
 		t.Fatalf("unexpected dry-run result: %+v", dry)
 	}
@@ -702,7 +702,7 @@ func TestSyncSkipsUnsupportedLocalUpdateByAdapterCapability(t *testing.T) {
 		t.Fatalf("unexpected dry-run action: %q", dry.Action)
 	}
 
-	applied := eng.runSyncApply(context.Background(), entry, SyncOptions{UpdateLocal: true})
+	applied := eng.runSyncApply(context.Background(), entry, SyncOptions{UpdateLocal: true}, nil)
 	if applied.Outcome != SyncOutcomeSkippedLocalUpdate || !applied.OK {
 		t.Fatalf("unexpected apply result: %+v", applied)
 	}

--- a/internal/engine/engine_sync_planexec_internal_test.go
+++ b/internal/engine/engine_sync_planexec_internal_test.go
@@ -44,7 +44,7 @@ func (e *Engine) planAndExecute(t *testing.T, entry registry.Entry, opts SyncOpt
 	t.Helper()
 	planOpts := opts
 	planOpts.DryRun = true
-	plan := e.runSyncDryRun(context.Background(), entry, planOpts)
+	plan := e.runSyncDryRun(context.Background(), entry, planOpts, nil)
 	execOpts := opts
 	execOpts.DryRun = false
 	execOpts.ContinueOnError = true
@@ -214,13 +214,13 @@ func TestPrepareSyncEntryUnknownFilterFailsClosed(t *testing.T) {
 	eng := newPlanExecEngine(&planAdapter{})
 	present := registry.Entry{RepoID: "repo", Path: "/repo", RemoteURL: "git@github.com:org/repo.git", Status: registry.StatusPresent}
 
-	queue, immediate := eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterKind("bogus")}, 0)
+	queue, _, immediate := eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterKind("bogus")}, 0)
 	if queue || immediate != nil {
 		t.Fatalf("expected unknown filter to fail closed (no queue, no result), got queue=%v immediate=%v", queue, immediate)
 	}
 
 	// A known non-inspect filter (all) still matches.
-	queue, immediate = eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterAll}, 0)
+	queue, _, immediate = eng.prepareSyncEntry(context.Background(), present, SyncOptions{Filter: FilterAll}, 0)
 	if !queue || immediate != nil {
 		t.Fatalf("expected FilterAll to queue the entry, got queue=%v immediate=%v", queue, immediate)
 	}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -44,6 +45,35 @@ func joinArgs(args []string) string {
 		out += arg
 	}
 	return out
+}
+
+// countingRunner behaves like mockRunner but records how many times each git
+// invocation is issued, so tests can assert that a command (e.g. the network-
+// touching `git remote prune --dry-run`) is not run more than once per repo.
+type countingRunner struct {
+	responses map[string]mockResponse
+	mu        sync.Mutex
+	counts    map[string]int
+}
+
+func (c *countingRunner) Run(_ context.Context, dir string, args ...string) (string, error) {
+	key := dir + ":" + joinArgs(args)
+	c.mu.Lock()
+	if c.counts == nil {
+		c.counts = map[string]int{}
+	}
+	c.counts[key]++
+	c.mu.Unlock()
+	if resp, ok := c.responses[key]; ok {
+		return resp.out, resp.err
+	}
+	return "", errors.New("unexpected call")
+}
+
+func (c *countingRunner) count(key string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts[key]
 }
 
 type blockingRunner struct {
@@ -105,6 +135,35 @@ var _ = Describe("Engine", func() {
 		Expect(results).To(HaveLen(1))
 		Expect(results[0].RemoteTrackingRefs.StaleCount).To(Equal(1))
 		Expect(results[0].RemoteTrackingRefs.Stale).To(Equal([]string{"origin/merged"}))
+	})
+
+	It("reuses the inspect-filter inspection instead of re-pruning during dry-run planning", func() {
+		runner := &countingRunner{responses: map[string]mockResponse{
+			"/repo:rev-parse --is-bare-repository":    {out: "false"},
+			"/repo:remote":                            {out: "origin"},
+			"/repo:remote get-url origin":             {out: "git@github.com:org/repo.git"},
+			"/repo:remote prune --dry-run -- origin":  {out: "Pruning origin\n * [would prune] origin/merged"},
+			"/repo:symbolic-ref --quiet --short HEAD": {out: "main"},
+			"/repo:status --porcelain=v1":             {out: "M  file.go\n"},
+			"/repo:for-each-ref --format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(upstream:trackshort) refs/heads": {
+				out: "main|origin/main||=",
+			},
+			"/repo:rev-list --left-right --count main...origin/main": {out: "0\t0"},
+			"/repo:config --file .gitmodules --get-regexp submodule": {err: errors.New("none")},
+		}}
+		reg := &registry.Registry{Entries: []registry.Entry{{
+			RepoID: "repo", Path: "/repo", RemoteURL: "git@github.com:org/repo.git", Status: registry.StatusPresent,
+		}}}
+		eng := engine.New(&config.Config{Defaults: config.Defaults{TimeoutSeconds: 1, Concurrency: 1}}, reg, vcs.NewGitAdapter(runner), nil, nil, nil)
+
+		// The dirty filter forces a live inspection (which prunes once as a dry
+		// run); the planner must reuse that data rather than pruning again.
+		results, err := eng.Sync(context.Background(), engine.SyncOptions{Filter: engine.FilterDirty, DryRun: true, Concurrency: 1, Timeout: 1})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].RemoteTrackingRefs.StaleCount).To(Equal(1))
+		Expect(results[0].RemoteTrackingRefs.Stale).To(Equal([]string{"origin/merged"}))
+		Expect(runner.count("/repo:remote prune --dry-run -- origin")).To(Equal(1))
 	})
 
 	It("keeps inspection usable when a remote cannot be queried", func() {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Engine", func() {
 			"/repo:rev-parse --is-bare-repository":    {out: "false"},
 			"/repo:remote":                            {out: "origin"},
 			"/repo:remote get-url origin":             {out: "git@github.com:org/repo.git"},
+			"/repo:remote prune --dry-run -- origin":  {out: "Pruning origin\n * [would prune] origin/merged"},
 			"/repo:symbolic-ref --quiet --short HEAD": {out: "main"},
 			"/repo:status --porcelain=v1":             {out: "M  file.go\n"},
 			"/repo:for-each-ref --format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(upstream:trackshort) refs/heads": {
@@ -84,6 +85,48 @@ var _ = Describe("Engine", func() {
 		Expect(status.RepoID).To(Equal("github.com/org/repo"))
 		Expect(status.Worktree).NotTo(BeNil())
 		Expect(status.Worktree.Dirty).To(BeTrue())
+		Expect(status.RemoteTrackingRefs.StaleCount).To(Equal(1))
+		Expect(status.RemoteTrackingRefs.Stale).To(Equal([]string{"origin/merged"}))
+	})
+
+	It("includes stale remote-tracking refs in a dry-run sync plan", func() {
+		runner := &mockRunner{responses: map[string]mockResponse{
+			"/repo1:remote":                           {out: "origin"},
+			"/repo1:remote get-url origin":            {out: "git@github.com:org/repo1.git"},
+			"/repo1:remote prune --dry-run -- origin": {out: "Pruning origin\n * [would prune] origin/merged"},
+		}}
+		reg := &registry.Registry{Entries: []registry.Entry{{
+			RepoID: "repo1", Path: "/repo1", RemoteURL: "git@github.com:org/repo1.git", Status: registry.StatusPresent,
+		}}}
+		eng := engine.New(&config.Config{Defaults: config.Defaults{TimeoutSeconds: 1, Concurrency: 1}}, reg, vcs.NewGitAdapter(runner), nil, nil, nil)
+
+		results, err := eng.Sync(context.Background(), engine.SyncOptions{DryRun: true, Concurrency: 1, Timeout: 1})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].RemoteTrackingRefs.StaleCount).To(Equal(1))
+		Expect(results[0].RemoteTrackingRefs.Stale).To(Equal([]string{"origin/merged"}))
+	})
+
+	It("keeps inspection usable when a remote cannot be queried", func() {
+		runner := &mockRunner{responses: map[string]mockResponse{
+			"/repo:rev-parse --is-bare-repository":    {out: "false"},
+			"/repo:remote":                            {out: "origin"},
+			"/repo:remote get-url origin":             {out: "git@github.com:org/repo.git"},
+			"/repo:remote prune --dry-run -- origin":  {err: errors.New("network unavailable")},
+			"/repo:symbolic-ref --quiet --short HEAD": {out: "main"},
+			"/repo:status --porcelain=v1":             {out: ""},
+			"/repo:for-each-ref --format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(upstream:trackshort) refs/heads": {
+				out: "main|origin/main||=",
+			},
+			"/repo:rev-list --left-right --count main...origin/main": {out: "0\t0"},
+			"/repo:config --file .gitmodules --get-regexp submodule": {err: errors.New("none")},
+		}}
+		eng := engine.New(&config.Config{}, &registry.Registry{}, vcs.NewGitAdapter(runner), nil, nil, nil)
+
+		status, err := eng.InspectRepo(context.Background(), "/repo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.RemoteTrackingRefs.StaleCount).To(BeZero())
+		Expect(status.RemoteTrackingRefs.InspectionError).To(ContainSubstring("network unavailable"))
 	})
 
 	It("syncs repositories with dry-run", func() {

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -147,11 +147,20 @@ var _ = Describe("Engine integration", func() {
 			},
 		}
 		eng := engine.New(&config.Config{Defaults: config.Defaults{TimeoutSeconds: 5, Concurrency: 1}}, reg, vcs.NewGitAdapter(nil), nil, nil, nil)
-		_, err := eng.Sync(context.Background(), engine.SyncOptions{Concurrency: 1, Timeout: 5})
+		status, err := eng.InspectRepo(context.Background(), work)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.RemoteTrackingRefs.StaleCount).To(Equal(1))
+		Expect(status.RemoteTrackingRefs.Stale).To(Equal([]string{"origin/feature"}))
+		Expect(strings.TrimSpace(runGit(work, "for-each-ref", "refs/remotes/origin/feature"))).To(ContainSubstring("origin/feature"), "inspection must not prune local refs")
+
+		_, err = eng.Sync(context.Background(), engine.SyncOptions{Concurrency: 1, Timeout: 5})
 		Expect(err).NotTo(HaveOccurred())
 
 		out := strings.TrimSpace(runGit(work, "for-each-ref", "refs/remotes/origin/feature"))
 		Expect(out).To(BeEmpty())
+		status, err = eng.InspectRepo(context.Background(), work)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.RemoteTrackingRefs.StaleCount).To(BeZero())
 	})
 
 	It("reports tracking gone after upstream branch is deleted", func() {

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/skaphos/repokeeper/internal/model"
@@ -214,6 +215,25 @@ func TrackingStatus(ctx context.Context, r Runner, dir string) (model.Tracking, 
 	}
 
 	return model.Tracking{Status: model.TrackingNone}, nil
+}
+
+// StaleRemoteTrackingRefs reports remote-tracking refs that git would remove
+// during a prune. The dry-run queries each remote without modifying local refs.
+func StaleRemoteTrackingRefs(ctx context.Context, r Runner, dir string, remoteNames []string) ([]string, error) {
+	stale := make([]string, 0)
+	for _, remote := range remoteNames {
+		remote = strings.TrimSpace(remote)
+		if remote == "" {
+			continue
+		}
+		out, err := r.Run(ctx, dir, "remote", "prune", "--dry-run", "--", remote)
+		if err != nil {
+			return nil, fmt.Errorf("git remote prune --dry-run %q: %w", remote, err)
+		}
+		stale = append(stale, ParseRemotePruneDryRun(out)...)
+	}
+	slices.Sort(stale)
+	return slices.Compact(stale), nil
 }
 
 func trackingFromShort(e ForEachRefEntry) model.Tracking {

--- a/internal/gitx/gitx_test.go
+++ b/internal/gitx/gitx_test.go
@@ -314,6 +314,33 @@ var _ = Describe("TrackingStatus", func() {
 	})
 })
 
+var _ = Describe("StaleRemoteTrackingRefs", func() {
+	It("returns sorted, deduplicated refs that a remote prune would remove", func() {
+		mock := &MockRunner{Responses: map[string]MockResponse{
+			"/repo:remote prune --dry-run -- origin": {
+				Output: "Pruning origin\nURL: git@example.com:org/repo.git\n * [would prune] origin/zeta\n * [would prune] origin/alpha",
+			},
+			"/repo:remote prune --dry-run -- upstream": {
+				Output: "Pruning upstream\n * [would prune] origin/alpha\n * [would prune] upstream/old",
+			},
+		}}
+
+		refs, err := gitx.StaleRemoteTrackingRefs(context.Background(), mock, "/repo", []string{"origin", "upstream"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(refs).To(Equal([]string{"origin/alpha", "origin/zeta", "upstream/old"}))
+	})
+
+	It("returns contextual errors without partial results", func() {
+		mock := &MockRunner{Responses: map[string]MockResponse{
+			"/repo:remote prune --dry-run -- origin": {Err: errors.New("network unavailable")},
+		}}
+
+		refs, err := gitx.StaleRemoteTrackingRefs(context.Background(), mock, "/repo", []string{"origin"})
+		Expect(err).To(MatchError(ContainSubstring(`git remote prune --dry-run "origin"`)))
+		Expect(refs).To(BeNil())
+	})
+})
+
 var _ = Describe("HasSubmodules", func() {
 	It("returns true when submodules exist", func() {
 		mock := &MockRunner{Responses: map[string]MockResponse{

--- a/internal/gitx/parse.go
+++ b/internal/gitx/parse.go
@@ -8,6 +8,27 @@ import (
 	"github.com/skaphos/repokeeper/internal/model"
 )
 
+const wouldPrunePrefix = "* [would prune] "
+
+// ParseRemotePruneDryRun extracts the ref names from git remote prune
+// --dry-run output. Header lines such as "Pruning origin" and "URL:" are
+// intentionally ignored.
+func ParseRemotePruneDryRun(output string) []string {
+	var refs []string
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		ref, ok := strings.CutPrefix(line, wouldPrunePrefix)
+		if !ok {
+			continue
+		}
+		ref = strings.TrimSpace(ref)
+		if ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
 // ParsePorcelainStatus parses the output of `git status --porcelain=v1`
 // into a Worktree struct.
 func ParsePorcelainStatus(output string) *model.Worktree {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1013,7 +1013,7 @@ var _ = Describe("MCPServer", func() {
 	Describe("plan_sync", func() {
 		BeforeEach(func() {
 			eng.syncResult = []engine.SyncResult{
-				{RepoID: "github.com/example/alpha", Path: "/home/user/repos/alpha", Action: "fetch --all --prune", Outcome: engine.SyncOutcomeFetched, Planned: true},
+				{RepoID: "github.com/example/alpha", Path: "/home/user/repos/alpha", Action: "fetch --all --prune", Outcome: engine.SyncOutcomeFetched, Planned: true, RemoteTrackingRefs: model.RemoteTrackingRefStatus{StaleCount: 1, Stale: []string{"origin/merged"}}},
 			}
 		})
 
@@ -1031,6 +1031,8 @@ var _ = Describe("MCPServer", func() {
 			Expect(entries).To(HaveLen(1))
 			Expect(entries[0]["planned"]).To(BeTrue())
 			Expect(entries[0]["repo_id"]).To(Equal("github.com/example/alpha"))
+			refs := entries[0]["remote_tracking_refs"].(map[string]any)
+			Expect(refs["stale_count"]).To(BeNumerically("==", 1))
 		})
 
 		It("returns empty wrapped plan when there are no sync actions", func() {

--- a/internal/mcpserver/tools_mutation.go
+++ b/internal/mcpserver/tools_mutation.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/skaphos/repokeeper/internal/config"
 	"github.com/skaphos/repokeeper/internal/engine"
+	"github.com/skaphos/repokeeper/internal/model"
 	"github.com/skaphos/repokeeper/internal/sortutil"
 )
 
@@ -112,12 +113,13 @@ func (s *MCPServer) handleScanWorkspace(ctx context.Context, req mcp.CallToolReq
 // --- plan_sync ---
 
 type syncPlanEntry struct {
-	RepoID     string `json:"repo_id"`
-	Path       string `json:"path"`
-	Action     string `json:"action"`
-	Outcome    string `json:"outcome"`
-	Planned    bool   `json:"planned"`
-	SkipReason string `json:"skip_reason,omitempty"`
+	RepoID             string                        `json:"repo_id"`
+	Path               string                        `json:"path"`
+	Action             string                        `json:"action"`
+	Outcome            string                        `json:"outcome"`
+	Planned            bool                          `json:"planned"`
+	SkipReason         string                        `json:"skip_reason,omitempty"`
+	RemoteTrackingRefs model.RemoteTrackingRefStatus `json:"remote_tracking_refs"`
 }
 
 func (s *MCPServer) handlePlanSync(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -135,12 +137,13 @@ func (s *MCPServer) handlePlanSync(ctx context.Context, req mcp.CallToolRequest)
 	entries := make([]syncPlanEntry, 0, len(results))
 	for _, r := range results {
 		entries = append(entries, syncPlanEntry{
-			RepoID:     r.RepoID,
-			Path:       r.Path,
-			Action:     r.Action,
-			Outcome:    string(r.Outcome),
-			Planned:    true,
-			SkipReason: r.SkipReason,
+			RepoID:             r.RepoID,
+			Path:               r.Path,
+			Action:             r.Action,
+			Outcome:            string(r.Outcome),
+			Planned:            true,
+			SkipReason:         r.SkipReason,
+			RemoteTrackingRefs: r.RemoteTrackingRefs,
 		})
 	}
 
@@ -150,13 +153,14 @@ func (s *MCPServer) handlePlanSync(ctx context.Context, req mcp.CallToolRequest)
 // --- execute_sync ---
 
 type syncResultEntry struct {
-	RepoID     string `json:"repo_id"`
-	Path       string `json:"path"`
-	Action     string `json:"action"`
-	Outcome    string `json:"outcome"`
-	OK         bool   `json:"ok"`
-	Error      string `json:"error,omitempty"`
-	SkipReason string `json:"skip_reason,omitempty"`
+	RepoID             string                        `json:"repo_id"`
+	Path               string                        `json:"path"`
+	Action             string                        `json:"action"`
+	Outcome            string                        `json:"outcome"`
+	OK                 bool                          `json:"ok"`
+	Error              string                        `json:"error,omitempty"`
+	SkipReason         string                        `json:"skip_reason,omitempty"`
+	RemoteTrackingRefs model.RemoteTrackingRefStatus `json:"remote_tracking_refs"`
 }
 
 func (s *MCPServer) handleExecuteSync(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -191,13 +195,14 @@ func (s *MCPServer) handleExecuteSync(ctx context.Context, req mcp.CallToolReque
 	entries := make([]syncResultEntry, 0, len(results))
 	for _, r := range results {
 		entries = append(entries, syncResultEntry{
-			RepoID:     r.RepoID,
-			Path:       r.Path,
-			Action:     r.Action,
-			Outcome:    string(r.Outcome),
-			OK:         r.OK,
-			Error:      r.Error,
-			SkipReason: r.SkipReason,
+			RepoID:             r.RepoID,
+			Path:               r.Path,
+			Action:             r.Action,
+			Outcome:            string(r.Outcome),
+			OK:                 r.OK,
+			Error:              r.Error,
+			SkipReason:         r.SkipReason,
+			RemoteTrackingRefs: r.RemoteTrackingRefs,
 		})
 	}
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -62,6 +62,16 @@ type Submodules struct {
 	HasSubmodules bool `json:"has_submodules" yaml:"has_submodules"`
 }
 
+// RemoteTrackingRefStatus describes remote-tracking refs that no longer exist
+// on their configured remotes. InspectionError is non-empty when the remote
+// could not be queried, so callers can distinguish an unavailable signal from
+// a repository with no stale refs.
+type RemoteTrackingRefStatus struct {
+	StaleCount      int      `json:"stale_count" yaml:"stale_count"`
+	Stale           []string `json:"stale,omitempty" yaml:"stale,omitempty"`
+	InspectionError string   `json:"inspection_error,omitempty" yaml:"inspection_error,omitempty"`
+}
+
 // SyncResult records the outcome of the last sync operation.
 type SyncResult struct {
 	// OK is true when the last sync completed successfully.
@@ -146,6 +156,8 @@ type RepoStatus struct {
 	Tracking Tracking `json:"tracking" yaml:"tracking"`
 	// Submodules indicates whether the repository contains submodules.
 	Submodules Submodules `json:"submodules" yaml:"submodules"`
+	// RemoteTrackingRefs describes refs that a fetch with prune would remove.
+	RemoteTrackingRefs RemoteTrackingRefStatus `json:"remote_tracking_refs" yaml:"remote_tracking_refs"`
 	// LastSync is the latest sync outcome metadata when available.
 	LastSync *SyncResult `json:"last_sync,omitempty" yaml:"last_sync,omitempty"`
 	// Error holds repository-specific inspect or sync error text.

--- a/internal/tui/actions_internal_test.go
+++ b/internal/tui/actions_internal_test.go
@@ -1139,17 +1139,18 @@ func TestViewsAndRendering(t *testing.T) {
 	t.Parallel()
 
 	baseRepo := model.RepoStatus{
-		RepoID:           "acme/backend",
-		Path:             "/work/backend",
-		Type:             "checkout",
-		PrimaryRemote:    "origin",
-		Head:             model.Head{Branch: "main"},
-		Tracking:         model.Tracking{Status: model.TrackingEqual, Upstream: "origin/main"},
-		Worktree:         &model.Worktree{Dirty: true, Staged: 1, Unstaged: 2, Untracked: 3},
-		Remotes:          []model.Remote{{Name: "origin", URL: "git@github.com:acme/backend.git"}},
-		Labels:           map[string]string{"team": "platform", "tier": "backend"},
-		Annotations:      map[string]string{"owner": "devx", "runbook": "docs/runbook.md"},
-		RepoMetadataFile: "/work/backend/.repokeeper-repo.yaml",
+		RepoID:             "acme/backend",
+		Path:               "/work/backend",
+		Type:               "checkout",
+		PrimaryRemote:      "origin",
+		Head:               model.Head{Branch: "main"},
+		Tracking:           model.Tracking{Status: model.TrackingEqual, Upstream: "origin/main"},
+		Worktree:           &model.Worktree{Dirty: true, Staged: 1, Unstaged: 2, Untracked: 3},
+		Remotes:            []model.Remote{{Name: "origin", URL: "git@github.com:acme/backend.git"}},
+		RemoteTrackingRefs: model.RemoteTrackingRefStatus{StaleCount: 1, Stale: []string{"origin/merged"}},
+		Labels:             map[string]string{"team": "platform", "tier": "backend"},
+		Annotations:        map[string]string{"owner": "devx", "runbook": "docs/runbook.md"},
+		RepoMetadataFile:   "/work/backend/.repokeeper-repo.yaml",
 		RepoMetadata: &model.RepoMetadata{
 			Name:        "Backend",
 			Labels:      map[string]string{"domain": "platform", "role": "service"},
@@ -1165,7 +1166,7 @@ func TestViewsAndRendering(t *testing.T) {
 	}
 
 	detail := renderDetailView(tuiModel{repos: []model.RepoStatus{baseRepo}, cursor: 0, width: 100})
-	for _, want := range []string{"Repository: acme/backend", "Path:", "/work/backend", "Remotes", "Labels", "Annotations", "Repo Metadata", "README.md", "api", "Last Sync", "Error:"} {
+	for _, want := range []string{"Repository: acme/backend", "Path:", "/work/backend", "Remotes", "Remote-tracking refs", "origin/merged", "Labels", "Annotations", "Repo Metadata", "README.md", "api", "Last Sync", "Error:"} {
 		if !strings.Contains(detail, want) {
 			t.Fatalf("detail view missing %q", want)
 		}

--- a/internal/tui/actions_internal_test.go
+++ b/internal/tui/actions_internal_test.go
@@ -1135,6 +1135,32 @@ func TestModalHelpers(t *testing.T) {
 	}
 }
 
+func TestDetailViewRendersUnknownStaleMarkerOnInspectionError(t *testing.T) {
+	t.Parallel()
+
+	repo := model.RepoStatus{
+		RepoID:   "acme/backend",
+		Path:     "/work/backend",
+		Type:     "checkout",
+		Head:     model.Head{Branch: "main"},
+		Tracking: model.Tracking{Status: model.TrackingEqual, Upstream: "origin/main"},
+		// Inspection failed, so StaleCount is an unreliable zero and must render
+		// as the same "?" marker the status table uses, not as "Stale: 0".
+		RemoteTrackingRefs: model.RemoteTrackingRefStatus{InspectionError: "network unavailable"},
+	}
+
+	detail := renderDetailView(tuiModel{repos: []model.RepoStatus{repo}, cursor: 0, width: 100})
+	if !strings.Contains(detail, "Stale: ?") {
+		t.Fatalf("expected unknown stale marker %q, got:\n%s", "Stale: ?", detail)
+	}
+	if strings.Contains(detail, "Stale: 0") {
+		t.Fatalf("inspection error must not render as a real zero count, got:\n%s", detail)
+	}
+	if !strings.Contains(detail, "network unavailable") {
+		t.Fatalf("expected inspection error text in detail view, got:\n%s", detail)
+	}
+}
+
 func TestViewsAndRendering(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -45,6 +45,19 @@ func renderDetailView(m tuiModel) string {
 		b.WriteByte('\n')
 	}
 
+	if r.RemoteTrackingRefs.StaleCount > 0 || r.RemoteTrackingRefs.InspectionError != "" {
+		b.WriteString(headerStyle.Render("Remote-tracking refs"))
+		b.WriteByte('\n')
+		fmt.Fprintf(&b, "  Stale: %d\n", r.RemoteTrackingRefs.StaleCount)
+		for _, ref := range r.RemoteTrackingRefs.Stale {
+			fmt.Fprintf(&b, "  - %s\n", sanitizeMetadataText(ref))
+		}
+		if r.RemoteTrackingRefs.InspectionError != "" {
+			fmt.Fprintf(&b, "  Error: %s\n", sanitizeMetadataText(r.RemoteTrackingRefs.InspectionError))
+		}
+		b.WriteByte('\n')
+	}
+
 	if len(r.Labels) > 0 {
 		b.WriteString(headerStyle.Render("Local Labels"))
 		b.WriteByte('\n')

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -48,7 +48,14 @@ func renderDetailView(m tuiModel) string {
 	if r.RemoteTrackingRefs.StaleCount > 0 || r.RemoteTrackingRefs.InspectionError != "" {
 		b.WriteString(headerStyle.Render("Remote-tracking refs"))
 		b.WriteByte('\n')
-		fmt.Fprintf(&b, "  Stale: %d\n", r.RemoteTrackingRefs.StaleCount)
+		staleDisplay := fmt.Sprintf("%d", r.RemoteTrackingRefs.StaleCount)
+		if r.RemoteTrackingRefs.InspectionError != "" {
+			// Inspection failed, so StaleCount is an unreliable zero: render an
+			// unknown marker to match the "?" the status table shows, so
+			// operators don't read "couldn't inspect" as "no stale refs".
+			staleDisplay = "?"
+		}
+		fmt.Fprintf(&b, "  Stale: %s\n", staleDisplay)
 		for _, ref := range r.RemoteTrackingRefs.Stale {
 			fmt.Fprintf(&b, "  - %s\n", sanitizeMetadataText(ref))
 		}

--- a/internal/vcs/adapter.go
+++ b/internal/vcs/adapter.go
@@ -34,6 +34,12 @@ type Adapter interface {
 	PrimaryRemote(remoteNames []string) string
 }
 
+// RemoteTrackingRefInspector is an optional adapter capability for detecting
+// refs that no longer exist upstream. Non-Git adapters need not implement it.
+type RemoteTrackingRefInspector interface {
+	StaleRemoteTrackingRefs(ctx context.Context, dir string, remoteNames []string) ([]string, error)
+}
+
 // GitAdapter implements Adapter using the git CLI via gitx.
 type GitAdapter struct {
 	Runner gitx.Runner
@@ -77,6 +83,10 @@ func (g *GitAdapter) WorktreeStatus(ctx context.Context, dir string) (*model.Wor
 
 func (g *GitAdapter) TrackingStatus(ctx context.Context, dir string) (model.Tracking, error) {
 	return gitx.TrackingStatus(ctx, g.Runner, dir)
+}
+
+func (g *GitAdapter) StaleRemoteTrackingRefs(ctx context.Context, dir string, remoteNames []string) ([]string, error) {
+	return gitx.StaleRemoteTrackingRefs(ctx, g.Runner, dir, remoteNames)
 }
 
 func (g *GitAdapter) HasSubmodules(ctx context.Context, dir string) (bool, error) {

--- a/internal/vcs/adapter_test.go
+++ b/internal/vcs/adapter_test.go
@@ -39,6 +39,7 @@ func TestGitAdapterMethods(t *testing.T) {
 		"/repo:rev-parse --is-bare-repository":    {out: "false"},
 		"/repo:remote":                            {out: "origin"},
 		"/repo:remote get-url origin":             {out: "git@github.com:Org/Repo.git"},
+		"/repo:remote prune --dry-run -- origin":  {out: "Pruning origin\n * [would prune] origin/merged"},
 		"/repo:symbolic-ref --quiet --short HEAD": {out: "main"},
 		"/repo:status --porcelain=v1":             {out: "M  file.go"},
 		"/repo:for-each-ref --format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(upstream:trackshort) refs/heads": {out: "main|origin/main||="},
@@ -74,6 +75,9 @@ func TestGitAdapterMethods(t *testing.T) {
 	}
 	if tr, err := a.TrackingStatus(context.Background(), "/repo"); err != nil || tr.Status == "" {
 		t.Fatalf("unexpected tracking: %v %#v", err, tr)
+	}
+	if refs, err := a.StaleRemoteTrackingRefs(context.Background(), "/repo", []string{"origin"}); err != nil || len(refs) != 1 || refs[0] != "origin/merged" {
+		t.Fatalf("unexpected stale refs: %v %#v", err, refs)
 	}
 	if has, err := a.HasSubmodules(context.Background(), "/repo"); err != nil || !has {
 		t.Fatalf("unexpected submodules: %v %v", err, has)

--- a/internal/vcs/factory.go
+++ b/internal/vcs/factory.go
@@ -121,6 +121,20 @@ func (m *MultiAdapter) TrackingStatus(ctx context.Context, dir string) (model.Tr
 	return adapter.TrackingStatus(ctx, dir)
 }
 
+// StaleRemoteTrackingRefs delegates the optional ref-inspection capability to
+// the backend selected for dir. Unsupported backends report no stale refs.
+func (m *MultiAdapter) StaleRemoteTrackingRefs(ctx context.Context, dir string, remoteNames []string) ([]string, error) {
+	adapter, err := m.adapterForPath(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	inspector, ok := adapter.(RemoteTrackingRefInspector)
+	if !ok {
+		return nil, nil
+	}
+	return inspector.StaleRemoteTrackingRefs(ctx, dir, remoteNames)
+}
+
 func (m *MultiAdapter) HasSubmodules(ctx context.Context, dir string) (bool, error) {
 	adapter, err := m.adapterForPath(ctx, dir)
 	if err != nil {

--- a/internal/vcs/factory_test.go
+++ b/internal/vcs/factory_test.go
@@ -54,6 +54,7 @@ type multiStubAdapter struct {
 	localUpdateOK    bool
 	localUpdateWhy   string
 	fetchActionLabel string
+	staleRefs        []string
 }
 
 func (m *multiStubAdapter) Name() string { return m.name }
@@ -113,6 +114,9 @@ func (m *multiStubAdapter) FetchAction(context.Context, string) (string, error) 
 	}
 	return m.fetchActionLabel, nil
 }
+func (m *multiStubAdapter) StaleRemoteTrackingRefs(context.Context, string, []string) ([]string, error) {
+	return m.staleRefs, nil
+}
 
 func TestMultiAdapterRoutesByPath(t *testing.T) {
 	gitAdapter := &multiStubAdapter{name: "git", repoPaths: map[string]bool{"/git-repo": true}, localUpdateOK: true}
@@ -149,6 +153,7 @@ func TestMultiAdapterRoutesCapabilityMethodsByPath(t *testing.T) {
 		repoPaths:        map[string]bool{"/git-repo": true},
 		localUpdateOK:    true,
 		fetchActionLabel: "git fetch --all --prune --prune-tags --no-recurse-submodules",
+		staleRefs:        []string{"origin/merged"},
 	}
 	hgAdapter := &multiStubAdapter{
 		name:             "hg",
@@ -179,6 +184,14 @@ func TestMultiAdapterRoutesCapabilityMethodsByPath(t *testing.T) {
 	}
 	if action != "hg pull" {
 		t.Fatalf("unexpected fetch action: %q", action)
+	}
+
+	refs, err := multi.StaleRemoteTrackingRefs(context.Background(), "/git-repo", []string{"origin"})
+	if err != nil {
+		t.Fatalf("stale remote refs returned error: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "origin/merged" {
+		t.Fatalf("unexpected stale remote refs: %#v", refs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- detect stale remote-tracking refs with non-mutating git remote prune dry-runs
- expose count, ref names, and non-fatal inspection errors in CLI, TUI, JSON, and MCP sync plans
- document the new Git invocation and machine-readable contracts

Closes SKA-220: https://linear.app/rillan/issue/SKA-220/detect-stale-remote-tracking-refs-during-inspection-and-sync-planning

## Testing

- GOCACHE=/tmp/repokeeper-go-build GOFLAGS=-mod=readonly GOPROXY=off go run github.com/onsi/ginkgo/v2/ginkgo ./...
- GOCACHE=/tmp/repokeeper-go-build GOFLAGS=-mod=readonly go test -coverprofile=/tmp/repokeeper-ska220-coverage.out ./...
- GOCACHE=/tmp/repokeeper-go-build GOFLAGS=-mod=readonly go test -tags=integration ./internal/engine
- GOCACHE=/tmp/repokeeper-go-build GOFLAGS=-mod=readonly GOLANGCI_LINT_CACHE=/tmp/repokeeper-golangci-cache golangci-lint run ./...
- gopls check on all changed Go implementation files

## Documentation

- updated README.md, docs/commands.md, docs/mcp-setup.md, and DESIGN.md
- recorded git remote prune --dry-run -- <remote> in the Git operations compatibility contract