### PR TITLE
chore: reassign copyright to Rillan AI LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Skaphos
+Copyright (c) 2026 Rillan AI LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Skaphos
+Copyright (c) 2026 Rillan AI LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -317,3 +317,9 @@ When dependencies change, regenerate the notice artifacts before opening a PR:
 ```bash
 go -C tools tool task notices
 ```
+
+---
+
+Skaphos is a project of [Rillan AI LLC](https://skaphos.io), a Missouri
+limited liability company. © 2026 Rillan AI LLC. Released under
+the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -322,4 +322,4 @@ go -C tools tool task notices
 
 Skaphos is a project of [Rillan AI LLC](https://skaphos.io), a Missouri
 limited liability company. © 2026 Rillan AI LLC. Released under
-the [MIT License](./LICENSE).
+the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

Reassigns copyright in this repository to **Rillan AI LLC**, a Missouri limited
liability company doing business as **Skaphos**, following the assignment of the
Skaphos IP to Rillan AI LLC and the Skaphos fictitious-name registration.

## Changes

- `LICENSE` (and `LICENSES/MIT.txt` where present): copyright holder → `Rillan AI LLC`.
- Per-file `SPDX-FileCopyrightText:` headers: holder → `Rillan AI LLC` (year unchanged).
- `README.md`: add the standard Rillan AI LLC / Skaphos footer.

The "Skaphos" name is retained everywhere as the project and brand name; only the
legal copyright holder changes. No code or runtime behavior changes.

## Testing

Text/metadata-only change. REUSE header format is preserved (holder token only),
so `reuse lint` and the DCO check remain satisfied; commits are DCO signed-off.