### PR TITLE
fix(mcp): keep registry state consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ repokeeper reconcile
 5. Re-run `repokeeper scan` whenever clones are added, moved, or removed so the embedded registry stays current.
 6. If needed, widen scope for a specific run with `repokeeper scan --roots <dir1,dir2,...>`.
 
+Scan treats each discovered repository root as a boundary and does not descend into it. Nested repositories or linked worktrees stored inside an already discovered working tree are therefore not registered separately and do not require extra exclude patterns.
+
 ## Commands
 
 Detailed command breakdown moved to docs:
@@ -163,7 +165,7 @@ repokeeper uninstall          # remove entries (prompts unless --yes)
 
 For runtimes without a flat-file MCP config RepoKeeper can adapter (Cursor, Windsurf), `repokeeper install --manual` prints the snippet you paste into their settings UI. See [docs/mcp-setup.md](docs/mcp-setup.md) for per-runtime paths, the full `install`/`uninstall` flag reference, and the MCP tool catalog.
 
-The MCP server is primarily intended for inspection and planning workflows with browsable resources, but the current tool surface also includes some explicit state-changing operations. Those mutation-capable tools follow the same safety gates and opt-in behavior as their CLI/TUI counterparts, so agents and users should treat them as execution surfaces when enabled.
+The MCP server is primarily intended for inspection and planning workflows with browsable resources, but the current tool surface also includes some explicit state-changing operations. Those mutation-capable tools follow the same safety gates and opt-in behavior as their CLI/TUI counterparts, so agents and users should treat them as execution surfaces when enabled. The server reloads workspace configuration and registry state from disk for every request, keeping long-running sessions current without silently reverting manual configuration edits.
 
 RepoKeeper is published to the MCP registry as `io.skaphos/repokeeper`.
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -121,6 +121,10 @@ Argument notes:
 - `plan_sync` entries include `remote_tracking_refs` with `stale_count`, the stale ref list, and a non-fatal `inspection_error` when a remote cannot be queried.
 - `scan_workspace.roots` is a string array of absolute or otherwise valid filesystem roots.
 - If `scan_workspace.roots` is omitted, RepoKeeper falls back to the effective workspace root resolved from the active config path.
+- Each MCP request reloads the config and registry from disk. Registry mutations merge their result into the latest on-disk config, so manual changes such as new `exclude` patterns are not overwritten by a running server.
+- `scan_workspace.new` counts registry entries added by that scan independently from entries pruned in the same call. `scan_workspace.missing` is the number of entries still marked missing after optional pruning.
+- `scan_workspace.prune_stale` uses `registry_stale_days` from the live config (default: 30), which is also returned by `get_workspace_config`.
+- Repository selectors accept `repo_id`, `checkout_id`, or an exact absolute checkout path. Use a checkout ID or path to disambiguate repositories with multiple registered checkouts.
 - `set_labels.set` is an object whose values must be strings.
 - `set_labels.remove` is a string array of label keys to delete.
 - `execute_sync.confirm` is a required safety gate. The call must include `"confirm": true`; omitting it or setting it to `false` is rejected.

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -43,27 +43,28 @@ func (e *Engine) ResetRepo(ctx context.Context, repoID, cfgPath string) error {
 	return nil
 }
 
-func (e *Engine) DeleteRepo(ctx context.Context, repoID, cfgPath string, deleteFiles bool) error {
+func (e *Engine) DeleteRepo(ctx context.Context, repo, cfgPath string, deleteFiles bool) error {
 	e.registryMu.Lock()
 	reg := e.registry
-	cfg := e.cfg
 	e.registryMu.Unlock()
 
 	if reg == nil {
 		return fmt.Errorf("registry not available")
 	}
-	entries := reg.FindEntriesByRepoID(repoID)
-	if len(entries) == 0 {
-		return fmt.Errorf("repo %q not found in registry", repoID)
+	entry, err := resolveDeleteEntry(reg, repo)
+	if err != nil {
+		return err
 	}
-	if len(entries) > 1 {
-		return fmt.Errorf("repo %q is ambiguous: found %d local checkouts; re-run with an exact checkout selector", repoID, len(entries))
+	entryPath := entry.Path
+	if deleteFiles && entryPath != "" {
+		if err := validateRemoveAllTarget(entryPath); err != nil {
+			return err
+		}
 	}
-	entryPath := entries[0].Path
 
 	newEntries := make([]registry.Entry, 0, len(reg.Entries))
 	for _, en := range reg.Entries {
-		if en.RepoID == repoID && en.Path == entryPath {
+		if en.RepoID == entry.RepoID && filepath.Clean(en.Path) == filepath.Clean(entryPath) {
 			continue
 		}
 		newEntries = append(newEntries, en)
@@ -74,8 +75,7 @@ func (e *Engine) DeleteRepo(ctx context.Context, repoID, cfgPath string, deleteF
 	reg.UpdatedAt = time.Now()
 	e.registryMu.Unlock()
 
-	cfg.Registry = reg
-	if err := config.Save(cfg, cfgPath); err != nil {
+	if err := e.persistRegistry(cfgPath); err != nil {
 		return fmt.Errorf("saving registry after delete: %w", err)
 	}
 
@@ -87,9 +87,61 @@ func (e *Engine) DeleteRepo(ctx context.Context, repoID, cfgPath string, deleteF
 	return nil
 }
 
+func resolveDeleteEntry(reg *registry.Registry, repo string) (registry.Entry, error) {
+	if filepath.IsAbs(repo) {
+		wantPath := filepath.Clean(repo)
+		var pathMatches []registry.Entry
+		for _, entry := range reg.Entries {
+			if filepath.Clean(entry.Path) == wantPath {
+				pathMatches = append(pathMatches, entry)
+			}
+		}
+		if len(pathMatches) == 1 {
+			return pathMatches[0], nil
+		}
+		if len(pathMatches) > 1 {
+			return registry.Entry{}, fmt.Errorf("repository path %q is ambiguous: found %d registry entries", repo, len(pathMatches))
+		}
+	}
+
+	var checkoutMatches []registry.Entry
+	for _, entry := range reg.Entries {
+		if entry.CheckoutID == repo {
+			checkoutMatches = append(checkoutMatches, entry)
+		}
+	}
+	if len(checkoutMatches) == 1 {
+		return checkoutMatches[0], nil
+	}
+	if len(checkoutMatches) > 1 {
+		return registry.Entry{}, fmt.Errorf("checkout_id %q is ambiguous: found %d registry entries", repo, len(checkoutMatches))
+	}
+
+	entries := reg.FindEntriesByRepoID(repo)
+	switch len(entries) {
+	case 0:
+		return registry.Entry{}, fmt.Errorf("repo %q not found in registry", repo)
+	case 1:
+		return entries[0], nil
+	default:
+		return registry.Entry{}, fmt.Errorf("repo %q is ambiguous: found %d local checkouts; re-run with an exact checkout selector", repo, len(entries))
+	}
+}
+
 // safeRemoveAll wraps os.RemoveAll with defensive checks to prevent accidental
 // deletion of non-absolute paths, filesystem roots, or non-directory targets.
 func safeRemoveAll(path string) error {
+	if err := validateRemoveAllTarget(path); err != nil {
+		return err
+	}
+	clean := filepath.Clean(path)
+	if err := os.RemoveAll(clean); err != nil {
+		return fmt.Errorf("deleting %q from disk: %w", clean, err)
+	}
+	return nil
+}
+
+func validateRemoveAllTarget(path string) error {
 	if !filepath.IsAbs(path) {
 		return fmt.Errorf("refusing to delete non-absolute path %q", path)
 	}
@@ -107,9 +159,6 @@ func safeRemoveAll(path string) error {
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("refusing to delete non-directory path %q", clean)
-	}
-	if err := os.RemoveAll(clean); err != nil {
-		return fmt.Errorf("deleting %q from disk: %w", clean, err)
 	}
 	return nil
 }
@@ -150,12 +199,38 @@ func (e *Engine) CloneAndRegister(ctx context.Context, remoteURL, targetPath, cf
 
 	e.registryMu.Lock()
 	reg := e.registry
-	cfg := e.cfg
 	e.registryMu.Unlock()
-	cfg.Registry = reg
-	if err := config.Save(cfg, cfgPath); err != nil {
+	if reg == nil {
+		return fmt.Errorf("registry not available")
+	}
+	if err := e.persistRegistry(cfgPath); err != nil {
 		return fmt.Errorf("saving registry after clone: %w", err)
 	}
+	return nil
+}
+
+func (e *Engine) persistRegistry(cfgPath string) error {
+	e.registryMu.Lock()
+	cfg := e.cfg
+	reg := e.registry
+	e.registryMu.Unlock()
+	if cfg == nil {
+		return fmt.Errorf("config not available")
+	}
+
+	if fresh, err := config.Load(cfgPath); err == nil {
+		cfg = fresh
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	cfg.Registry = reg
+	if err := config.Save(cfg, cfgPath); err != nil {
+		return err
+	}
+
+	e.registryMu.Lock()
+	e.cfg = cfg
+	e.registryMu.Unlock()
 	return nil
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -130,6 +130,22 @@ func (e *Engine) Config() *config.Config { return e.cfg }
 // Registry returns the engine registry reference.
 func (e *Engine) Registry() *registry.Registry { return e.registry }
 
+// ReloadConfig refreshes the engine configuration and registry from disk.
+func (e *Engine) ReloadConfig(path string) error {
+	cfg, err := config.Load(path)
+	if err != nil {
+		return err
+	}
+	if cfg.Registry == nil {
+		return fmt.Errorf("registry not found in %q", path)
+	}
+	e.registryMu.Lock()
+	e.cfg = cfg
+	e.registry = cfg.Registry
+	e.registryMu.Unlock()
+	return nil
+}
+
 // Adapter returns the engine VCS adapter.
 func (e *Engine) Adapter() vcs.Adapter { return e.adapter }
 

--- a/internal/engine/engine_actions_import_repair_internal_test.go
+++ b/internal/engine/engine_actions_import_repair_internal_test.go
@@ -652,6 +652,57 @@ func TestActionsResetDeleteCloneAndRegister(t *testing.T) {
 		if err := eng.DeleteRepo(context.Background(), "repo", cfgPath, false); err == nil || !strings.Contains(err.Error(), "ambiguous") {
 			t.Fatalf("expected ambiguous repo error, got %v", err)
 		}
+		eng.registry = &registry.Registry{Entries: []registry.Entry{
+			{RepoID: "first", Path: "/shared", Status: registry.StatusPresent},
+			{RepoID: "second", Path: "/shared", Status: registry.StatusPresent},
+		}}
+		if err := eng.DeleteRepo(context.Background(), "/shared", cfgPath, false); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+			t.Fatalf("expected duplicate path ambiguity error, got %v", err)
+		}
+		if len(eng.registry.Entries) != 2 {
+			t.Fatalf("ambiguous path must not remove entries, got %+v", eng.registry.Entries)
+		}
+
+		eng.registry = &registry.Registry{Entries: []registry.Entry{{RepoID: "root", Path: string(filepath.Separator), Status: registry.StatusPresent}}}
+		if err := eng.DeleteRepo(context.Background(), string(filepath.Separator), cfgPath, true); err == nil || !strings.Contains(err.Error(), "filesystem root") {
+			t.Fatalf("expected filesystem root rejection, got %v", err)
+		}
+		if len(eng.registry.Entries) != 1 {
+			t.Fatalf("unsafe delete target must remain registered, got %+v", eng.registry.Entries)
+		}
+
+		eng.registry = &registry.Registry{Entries: []registry.Entry{
+			{RepoID: "repo", Path: "/repo-a", CheckoutID: "co-a", Status: registry.StatusPresent},
+			{RepoID: "repo", Path: "/repo-b", CheckoutID: "co-b", Status: registry.StatusPresent},
+		}}
+		if err := eng.DeleteRepo(context.Background(), "/repo-b", cfgPath, false); err != nil {
+			t.Fatalf("delete exact checkout path: %v", err)
+		}
+		if len(eng.registry.Entries) != 1 || eng.registry.Entries[0].Path != "/repo-a" {
+			t.Fatalf("expected only /repo-b removed, entries=%+v", eng.registry.Entries)
+		}
+
+		eng.registry = &registry.Registry{Entries: []registry.Entry{
+			{RepoID: "repo", Path: "/repo-a", CheckoutID: "co-a", Status: registry.StatusPresent},
+			{RepoID: "repo", Path: "/repo-b", CheckoutID: "co-b", Status: registry.StatusPresent},
+		}}
+		if err := eng.DeleteRepo(context.Background(), "co-a", cfgPath, false); err != nil {
+			t.Fatalf("delete exact checkout ID: %v", err)
+		}
+		if len(eng.registry.Entries) != 1 || eng.registry.Entries[0].Path != "/repo-b" {
+			t.Fatalf("expected only checkout co-a removed, entries=%+v", eng.registry.Entries)
+		}
+
+		eng.registry = &registry.Registry{Entries: []registry.Entry{
+			{RepoID: "path-owner", Path: "co-b", CheckoutID: "path-owner", Status: registry.StatusPresent},
+			{RepoID: "repo", Path: "/repo-b", CheckoutID: "co-b", Status: registry.StatusPresent},
+		}}
+		if err := eng.DeleteRepo(context.Background(), "co-b", cfgPath, false); err != nil {
+			t.Fatalf("delete checkout ID that collides with a relative path: %v", err)
+		}
+		if len(eng.registry.Entries) != 1 || eng.registry.Entries[0].RepoID != "path-owner" {
+			t.Fatalf("relative path collision selected the wrong entry: %+v", eng.registry.Entries)
+		}
 
 		keepPath := filepath.Join(t.TempDir(), "keep")
 		if err := os.MkdirAll(keepPath, 0o755); err != nil {
@@ -784,6 +835,64 @@ func TestActionsResetDeleteCloneAndRegister(t *testing.T) {
 			t.Fatalf("expected stored RemoteURL trimmed, got %q", entry.RemoteURL)
 		}
 	})
+}
+
+func TestReloadConfigAndRegistryPersistenceUseLatestDiskState(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	diskCfg := config.DefaultConfig()
+	diskCfg.Exclude = []string{"**/startup/**"}
+	diskCfg.Registry = &registry.Registry{Entries: []registry.Entry{
+		{RepoID: "repo", CheckoutID: "first", Path: "/repo-a", Status: registry.StatusPresent},
+		{RepoID: "repo", CheckoutID: "second", Path: "/repo-b", Status: registry.StatusPresent},
+	}}
+	if err := config.Save(&diskCfg, cfgPath); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+
+	startupCfg := config.DefaultConfig()
+	eng := New(&startupCfg, &registry.Registry{}, vcs.NewGitAdapter(&testRunner{}), nil, nil, nil)
+
+	edited, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config for manual edit: %v", err)
+	}
+	edited.Exclude = []string{"**/edited-after-startup/**"}
+	if err := config.Save(edited, cfgPath); err != nil {
+		t.Fatalf("save manual config edit: %v", err)
+	}
+
+	if err := eng.ReloadConfig(cfgPath); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if got := eng.Config().Exclude; len(got) != 1 || got[0] != "**/edited-after-startup/**" {
+		t.Fatalf("expected refreshed excludes, got %v", got)
+	}
+	if got := len(eng.Registry().Entries); got != 2 {
+		t.Fatalf("expected refreshed registry with 2 entries, got %d", got)
+	}
+
+	if err := eng.DeleteRepo(context.Background(), "/repo-b", cfgPath, false); err != nil {
+		t.Fatalf("delete exact checkout: %v", err)
+	}
+	persisted, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload persisted config: %v", err)
+	}
+	if got := persisted.Exclude; len(got) != 1 || got[0] != "**/edited-after-startup/**" {
+		t.Fatalf("registry write clobbered manual excludes: %v", got)
+	}
+	if len(persisted.Registry.Entries) != 1 || persisted.Registry.Entries[0].Path != "/repo-a" {
+		t.Fatalf("expected only exact checkout removed, entries=%+v", persisted.Registry.Entries)
+	}
+
+	missingRegistryPath := filepath.Join(t.TempDir(), "config.yaml")
+	missingRegistryCfg := config.DefaultConfig()
+	if err := config.Save(&missingRegistryCfg, missingRegistryPath); err != nil {
+		t.Fatalf("save config without registry: %v", err)
+	}
+	if err := eng.ReloadConfig(missingRegistryPath); err == nil || !strings.Contains(err.Error(), "registry not found") {
+		t.Fatalf("expected reload to fail closed without registry, got %v", err)
+	}
 }
 
 func TestRemoteMismatchWrapperFunctions(t *testing.T) {

--- a/internal/engine/repair.go
+++ b/internal/engine/repair.go
@@ -112,10 +112,7 @@ func (e *Engine) RepairUpstream(ctx context.Context, repoID, cfgPath string) (Re
 	entry.Status = registry.StatusPresent
 	e.upsertRegistryEntry(entry)
 
-	e.registryMu.Lock()
-	defer e.registryMu.Unlock()
-	cfg.Registry = e.registry
-	if err := config.Save(cfg, cfgPath); err != nil {
+	if err := e.persistRegistry(cfgPath); err != nil {
 		return res, fmt.Errorf("repair succeeded but config save failed: %w", err)
 	}
 

--- a/internal/mcpserver/engine.go
+++ b/internal/mcpserver/engine.go
@@ -30,6 +30,7 @@ type EngineAPI interface {
 	DeleteRepo(ctx context.Context, repoID, cfgPath string, deleteFiles bool) error
 	CloneAndRegister(ctx context.Context, remoteURL, targetPath, cfgPath string, mirror bool) error
 	Scan(ctx context.Context, opts engine.ScanOptions) ([]model.RepoStatus, error)
+	ReloadConfig(path string) error
 	Registry() *registry.Registry
 	Config() *config.Config
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -37,10 +37,14 @@ type mockEngine struct {
 	syncErr          error
 	scanResult       []model.RepoStatus
 	scanErr          error
+	scanFunc         func(engine.ScanOptions) ([]model.RepoStatus, error)
 	deleteRepoCalled bool
+	deleteRepoArg    string
 	deleteRepoErr    error
 	cloneCalled      bool
 	cloneErr         error
+	reloadFromDisk   bool
+	reloadErr        error
 }
 
 func (e *mockEngine) Status(_ context.Context, opts engine.StatusOptions) (*model.StatusReport, error) {
@@ -102,17 +106,21 @@ func (e *mockEngine) InspectRepo(_ context.Context, path string) (*model.RepoSta
 		},
 	}, nil
 }
-func (e *mockEngine) DeleteRepo(_ context.Context, _, _ string, _ bool) error {
+func (e *mockEngine) DeleteRepo(_ context.Context, repo string, _ string, _ bool) error {
 	e.deleteRepoCalled = true
+	e.deleteRepoArg = repo
 	return e.deleteRepoErr
 }
 func (e *mockEngine) CloneAndRegister(_ context.Context, _, _, _ string, _ bool) error {
 	e.cloneCalled = true
 	return e.cloneErr
 }
-func (e *mockEngine) Scan(_ context.Context, _ engine.ScanOptions) ([]model.RepoStatus, error) {
+func (e *mockEngine) Scan(_ context.Context, opts engine.ScanOptions) ([]model.RepoStatus, error) {
 	if e.scanErr != nil {
 		return nil, e.scanErr
+	}
+	if e.scanFunc != nil {
+		return e.scanFunc(opts)
 	}
 	if e.scanResult != nil {
 		return e.scanResult, nil
@@ -121,6 +129,22 @@ func (e *mockEngine) Scan(_ context.Context, _ engine.ScanOptions) ([]model.Repo
 }
 func (e *mockEngine) Registry() *registry.Registry { return e.reg }
 func (e *mockEngine) Config() *config.Config       { return e.cfg }
+
+func (e *mockEngine) ReloadConfig(path string) error {
+	if e.reloadErr != nil {
+		return e.reloadErr
+	}
+	if !e.reloadFromDisk {
+		return nil
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		return err
+	}
+	e.cfg = cfg
+	e.reg = cfg.Registry
+	return nil
+}
 
 var _ mcpserver.EngineAPI = (*mockEngine)(nil)
 
@@ -487,6 +511,7 @@ var _ = Describe("MCPServer", func() {
 			Expect(json.Unmarshal(resultJSON(result), &resp)).To(Succeed())
 			Expect(resp["config_path"]).To(HaveSuffix(".repokeeper.yaml"))
 			Expect(resp["repo_count"]).To(BeNumerically("==", 3))
+			Expect(resp["registry_stale_days"]).To(BeNumerically("==", 30))
 
 			defaults := resp["defaults"].(map[string]any)
 			Expect(defaults["remote_name"]).To(Equal("origin"))
@@ -498,6 +523,28 @@ var _ = Describe("MCPServer", func() {
 			result, err := callTool(srv, "get_workspace_config", nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeTrue())
+		})
+
+		It("reloads config and registry changes made after server startup", func() {
+			cfgPath := filepath.Join(tmpDir, ".repokeeper.yaml")
+			eng.cfg.Registry = eng.reg
+			Expect(config.Save(eng.cfg, cfgPath)).To(Succeed())
+
+			onDisk, err := config.Load(cfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			onDisk.Exclude = []string{"**/manually-added/**"}
+			onDisk.Registry.Entries = onDisk.Registry.Entries[:2]
+			Expect(config.Save(onDisk, cfgPath)).To(Succeed())
+			eng.reloadFromDisk = true
+
+			result, err := callTool(srv, "get_workspace_config", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			var resp map[string]any
+			Expect(json.Unmarshal(resultJSON(result), &resp)).To(Succeed())
+			Expect(resp["exclude"]).To(ConsistOf("**/manually-added/**"))
+			Expect(resp["repo_count"]).To(BeNumerically("==", 2))
 		})
 	})
 
@@ -1008,6 +1055,70 @@ var _ = Describe("MCPServer", func() {
 			text := string(resultJSON(result))
 			Expect(text).To(ContainSubstring(`argument "roots" item 1 must be a string`))
 		})
+
+		It("counts additions independently from pruning and reports current missing entries", func() {
+			now := time.Now()
+			eng.reg = &registry.Registry{Entries: []registry.Entry{
+				{RepoID: "github.com/example/existing", CheckoutID: "existing", Path: "/repos/existing", Status: registry.StatusPresent, LastSeen: now},
+				{RepoID: "github.com/example/stale", Path: "/repos/stale", Status: registry.StatusMissing, LastSeen: now.Add(-60 * 24 * time.Hour)},
+				{RepoID: "github.com/example/recent-missing", Path: "/repos/recent-missing", Status: registry.StatusMissing, LastSeen: now.Add(-7 * 24 * time.Hour)},
+			}}
+			eng.cfg = newTestConfig()
+			eng.cfg.RegistryStaleDays = 30
+			eng.scanFunc = func(_ engine.ScanOptions) ([]model.RepoStatus, error) {
+				eng.reg.Entries[0].Path = "/repos/existing-moved"
+				eng.reg.Entries = append(eng.reg.Entries, registry.Entry{
+					RepoID: "github.com/example/new",
+					Path:   "/repos/new",
+					Status: registry.StatusPresent,
+				})
+				return []model.RepoStatus{{RepoID: "github.com/example/new", Path: "/repos/new"}}, nil
+			}
+
+			result, err := callTool(srv, "scan_workspace", map[string]any{"prune_stale": true})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			var resp map[string]any
+			Expect(json.Unmarshal(resultJSON(result), &resp)).To(Succeed())
+			Expect(resp["new"]).To(BeNumerically("==", 1))
+			Expect(resp["pruned"]).To(BeNumerically("==", 1))
+			Expect(resp["missing"]).To(BeNumerically("==", 1))
+		})
+
+		It("uses and preserves config edits made after server startup", func() {
+			cfgPath := filepath.Join(tmpDir, ".repokeeper.yaml")
+			eng.cfg.Registry = eng.reg
+			Expect(config.Save(eng.cfg, cfgPath)).To(Succeed())
+
+			onDisk, err := config.Load(cfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			onDisk.Exclude = []string{"**/manually-added/**"}
+			Expect(config.Save(onDisk, cfgPath)).To(Succeed())
+			eng.reloadFromDisk = true
+			eng.scanFunc = func(opts engine.ScanOptions) ([]model.RepoStatus, error) {
+				if len(opts.Exclude) != 1 || opts.Exclude[0] != "**/manually-added/**" {
+					return nil, fmt.Errorf("scan used stale excludes: %v", opts.Exclude)
+				}
+				concurrentEdit, err := config.Load(cfgPath)
+				if err != nil {
+					return nil, err
+				}
+				concurrentEdit.Exclude = []string{"**/edited-during-scan/**"}
+				if err := config.Save(concurrentEdit, cfgPath); err != nil {
+					return nil, err
+				}
+				return []model.RepoStatus{}, nil
+			}
+
+			result, err := callTool(srv, "scan_workspace", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			reloaded, err := config.Load(cfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reloaded.Exclude).To(Equal([]string{"**/edited-during-scan/**"}))
+		})
 	})
 
 	Describe("plan_sync", func() {
@@ -1327,6 +1438,17 @@ var _ = Describe("MCPServer", func() {
 			Expect(resp["repo_id"]).To(Equal("github.com/example/beta"))
 		})
 
+		It("passes the exact checkout path through when a repo has multiple checkouts", func() {
+			eng.reg = registryWithDuplicateRepoID()
+
+			result, err := callTool(srv, "remove_repository", map[string]any{
+				"repo": "/home/user/repos/dup-b",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+			Expect(eng.deleteRepoArg).To(Equal("/home/user/repos/dup-b"))
+		})
+
 		It("returns error for an unknown repo before touching the engine", func() {
 			result, err := callTool(srv, "remove_repository", map[string]any{
 				"repo": "/home/user/repos/does-not-exist",
@@ -1430,18 +1552,20 @@ func registryWithDuplicateRepoID() *registry.Registry {
 		UpdatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 		Entries: []registry.Entry{
 			{
-				RepoID:   "github.com/example/dup",
-				Path:     "/home/user/repos/dup-a",
-				Type:     "checkout",
-				Status:   registry.StatusPresent,
-				LastSeen: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+				RepoID:     "github.com/example/dup",
+				CheckoutID: "dup-a",
+				Path:       "/home/user/repos/dup-a",
+				Type:       "checkout",
+				Status:     registry.StatusPresent,
+				LastSeen:   time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 			},
 			{
-				RepoID:   "github.com/example/dup",
-				Path:     "/home/user/repos/dup-b",
-				Type:     "checkout",
-				Status:   registry.StatusPresent,
-				LastSeen: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+				RepoID:     "github.com/example/dup",
+				CheckoutID: "dup-b",
+				Path:       "/home/user/repos/dup-b",
+				Type:       "checkout",
+				Status:     registry.StatusPresent,
+				LastSeen:   time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 			},
 		},
 	}
@@ -1467,7 +1591,11 @@ var _ = Describe("resolveRepo ambiguity", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.IsError).To(BeTrue())
-		Expect(string(resultJSON(result))).To(ContainSubstring("ambiguous"))
+		Expect(string(resultJSON(result))).To(And(
+			ContainSubstring("ambiguous"),
+			ContainSubstring(`checkout_id="dup-a"`),
+			ContainSubstring(`/home/user/repos/dup-b`),
+		))
 	})
 
 	It("errors on get_repository_context for an ambiguous repo_id", func() {
@@ -1488,6 +1616,44 @@ var _ = Describe("resolveRepo ambiguity", func() {
 		Expect(result.IsError).To(BeFalse())
 		Expect(eng.reg.Entries[1].Labels).To(HaveKeyWithValue("tier", "critical"))
 		Expect(eng.reg.Entries[0].Labels).To(BeNil())
+	})
+
+	It("disambiguates via checkout_id", func() {
+		result, err := callTool(srv, "get_repository_context", map[string]any{
+			"repo": "dup-b",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsError).To(BeFalse())
+	})
+
+	It("does not treat a relative selector as a path", func() {
+		eng.reg = &registry.Registry{Entries: []registry.Entry{
+			{RepoID: "github.com/example/path-owner", CheckoutID: "path-owner", Path: "checkout-b"},
+			{RepoID: "github.com/example/checkout-owner", CheckoutID: "checkout-b", Path: "/home/user/repos/checkout-b"},
+		}}
+
+		result, err := callTool(srv, "set_labels", map[string]any{
+			"repo": "checkout-b",
+			"set":  map[string]any{"selected": "checkout-id"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsError).To(BeFalse())
+		Expect(eng.reg.Entries[0].Labels).To(BeNil())
+		Expect(eng.reg.Entries[1].Labels).To(HaveKeyWithValue("selected", "checkout-id"))
+	})
+
+	It("rejects a path shared by multiple registry entries", func() {
+		eng.reg = &registry.Registry{Entries: []registry.Entry{
+			{RepoID: "github.com/example/first", Path: "/home/user/repos/shared"},
+			{RepoID: "github.com/example/second", Path: "/home/user/repos/shared"},
+		}}
+
+		result, err := callTool(srv, "get_repository_context", map[string]any{
+			"repo": "/home/user/repos/shared",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IsError).To(BeTrue())
+		Expect(string(resultJSON(result))).To(ContainSubstring("ambiguous"))
 	})
 })
 

--- a/internal/mcpserver/resolve.go
+++ b/internal/mcpserver/resolve.go
@@ -4,12 +4,13 @@ package mcpserver
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/skaphos/repokeeper/internal/registry"
 )
 
-// resolveRepo resolves a repo identifier (repo_id or absolute path) to a
-// registry entry.
+// resolveRepo resolves a repo identifier (absolute path, checkout_id, or
+// repo_id) to a registry entry.
 //
 // An absolute path selects a single checkout unambiguously, so it is matched
 // first. A repo_id may resolve to multiple local checkouts; rather than
@@ -22,20 +23,41 @@ func resolveRepo(reg *registry.Registry, repo string) (*registry.Entry, error) {
 		return nil, fmt.Errorf("registry not loaded")
 	}
 
-	// An absolute path identifies exactly one checkout. Normalize both sides
-	// with filepath.Clean so equivalent-but-non-canonical forms (e.g. a
-	// trailing slash, or "." / ".." segments) still match the stored path.
+	// An exact path identifies one checkout. Normalize both sides so
+	// equivalent-but-non-canonical forms (e.g. a trailing slash, or "." /
+	// ".." segments) still match the stored path.
 	if filepath.IsAbs(repo) {
 		want := filepath.Clean(repo)
+		var pathMatches []int
 		for i := range reg.Entries {
 			if filepath.Clean(reg.Entries[i].Path) == want {
-				return &reg.Entries[i], nil
+				pathMatches = append(pathMatches, i)
 			}
 		}
-		return nil, fmt.Errorf("repository %q not found in registry", repo)
+		if len(pathMatches) == 1 {
+			return &reg.Entries[pathMatches[0]], nil
+		}
+		if len(pathMatches) > 1 {
+			return nil, fmt.Errorf("repository path %q is ambiguous: found %d registry entries", repo, len(pathMatches))
+		}
 	}
 
-	// Otherwise treat the identifier as a repo_id, which may map to several
+	// checkout_id is the next-most-specific selector. Reject collisions rather
+	// than picking an arbitrary repository when two entries share an ID.
+	var checkoutMatches []int
+	for i := range reg.Entries {
+		if reg.Entries[i].CheckoutID == repo {
+			checkoutMatches = append(checkoutMatches, i)
+		}
+	}
+	if len(checkoutMatches) == 1 {
+		return &reg.Entries[checkoutMatches[0]], nil
+	}
+	if len(checkoutMatches) > 1 {
+		return nil, fmt.Errorf("checkout_id %q is ambiguous: found %d repositories; pass the checkout's absolute path instead", repo, len(checkoutMatches))
+	}
+
+	// Finally treat the identifier as a repo_id, which may map to several
 	// checkouts. Collect all matches so ambiguity can be detected.
 	var matches []int
 	for i := range reg.Entries {
@@ -49,6 +71,11 @@ func resolveRepo(reg *registry.Registry, repo string) (*registry.Entry, error) {
 	case 1:
 		return &reg.Entries[matches[0]], nil
 	default:
-		return nil, fmt.Errorf("repo %q is ambiguous: found %d local checkouts; pass the checkout's absolute path instead", repo, len(matches))
+		selectors := make([]string, 0, len(matches))
+		for _, match := range matches {
+			entry := reg.Entries[match]
+			selectors = append(selectors, fmt.Sprintf("checkout_id=%q or path=%q", entry.CheckoutID, entry.Path))
+		}
+		return nil, fmt.Errorf("repo %q is ambiguous: found %d local checkouts; use %s", repo, len(matches), strings.Join(selectors, "; "))
 	}
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -3,7 +3,9 @@ package mcpserver
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -108,6 +110,9 @@ func (s *MCPServer) serializeTool(h server.ToolHandlerFunc) server.ToolHandlerFu
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
+		if err := s.reloadConfig(); err != nil {
+			return newToolErrorf("reload config: %w", err), nil
+		}
 		res, err := h(ctx, req)
 		// Translating here rather than per-handler covers every mutating
 		// tool at one point. Read-only tools never produce EROFS, so the
@@ -127,8 +132,18 @@ func (s *MCPServer) serializeResource(
 	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
+		if err := s.reloadConfig(); err != nil {
+			return nil, fmt.Errorf("reload config: %w", err)
+		}
 		return h(ctx, req)
 	}
+}
+
+func (s *MCPServer) reloadConfig() error {
+	if s.engine == nil || strings.TrimSpace(s.cfgPath) == "" {
+		return nil
+	}
+	return s.engine.ReloadConfig(s.cfgPath)
 }
 
 // --- Tool definitions ---
@@ -155,7 +170,7 @@ func getRepositoryContextTool() mcp.Tool {
 			ReadOnlyHint: boolPtr(true),
 		}),
 		mcp.WithString("repo",
-			mcp.Description("Repository identifier (repo_id or absolute path)"),
+			mcp.Description("Repository identifier (repo_id, checkout_id, or absolute path)"),
 			mcp.Required(),
 		),
 	)
@@ -213,7 +228,7 @@ func getRepoMetadataTool() mcp.Tool {
 			ReadOnlyHint: boolPtr(true),
 		}),
 		mcp.WithString("repo",
-			mcp.Description("Repository identifier (repo_id or absolute path)"),
+			mcp.Description("Repository identifier (repo_id, checkout_id, or absolute path)"),
 			mcp.Required(),
 		),
 	)
@@ -226,7 +241,7 @@ func getAuthoritativePathsTool() mcp.Tool {
 			ReadOnlyHint: boolPtr(true),
 		}),
 		mcp.WithString("repo",
-			mcp.Description("Repository identifier (repo_id or absolute path)"),
+			mcp.Description("Repository identifier (repo_id, checkout_id, or absolute path)"),
 			mcp.Required(),
 		),
 	)
@@ -239,7 +254,7 @@ func getRelatedRepositoriesTool() mcp.Tool {
 			ReadOnlyHint: boolPtr(true),
 		}),
 		mcp.WithString("repo",
-			mcp.Description("Repository identifier (repo_id or absolute path)"),
+			mcp.Description("Repository identifier (repo_id, checkout_id, or absolute path)"),
 			mcp.Required(),
 		),
 	)
@@ -320,7 +335,7 @@ func setLabelsTool() mcp.Tool {
 			ReadOnlyHint: boolPtr(false),
 		}),
 		mcp.WithString("repo",
-			mcp.Description("Repository identifier (repo_id or absolute path)"),
+			mcp.Description("Repository identifier (repo_id, checkout_id, or absolute path)"),
 			mcp.Required(),
 		),
 		mcp.WithObject("set",
@@ -362,7 +377,7 @@ func removeRepositoryTool() mcp.Tool {
 			DestructiveHint: boolPtr(true),
 		}),
 		mcp.WithString("repo",
-			mcp.Description("Repository identifier (repo_id or absolute path)"),
+			mcp.Description("Repository identifier (repo_id, checkout_id, or absolute path)"),
 			mcp.Required(),
 		),
 		mcp.WithBoolean("delete_files",

--- a/internal/mcpserver/tools_config.go
+++ b/internal/mcpserver/tools_config.go
@@ -15,6 +15,7 @@ type workspaceConfigResponse struct {
 	Exclude      []string       `json:"exclude,omitempty"`
 	IgnoredPaths []string       `json:"ignored_paths,omitempty"`
 	RegistryPath string         `json:"registry_path,omitempty"`
+	StaleDays    int            `json:"registry_stale_days"`
 	Defaults     configDefaults `json:"defaults"`
 	RepoCount    int            `json:"repo_count"`
 }
@@ -42,6 +43,7 @@ func (s *MCPServer) handleGetWorkspaceConfig(_ context.Context, _ mcp.CallToolRe
 		Exclude:      cfg.Exclude,
 		IgnoredPaths: cfg.IgnoredPaths,
 		RegistryPath: cfg.RegistryPath,
+		StaleDays:    positiveIntDefault(cfg.RegistryStaleDays, config.DefaultConfig().RegistryStaleDays),
 		Defaults: configDefaults{
 			RemoteName:     cfgDefault(cfg.Defaults.RemoteName, config.DefaultConfig().Defaults.RemoteName),
 			MainBranch:     cfgDefault(cfg.Defaults.MainBranch, config.DefaultConfig().Defaults.MainBranch),
@@ -63,6 +65,13 @@ func cfgDefault(val, fallback string) string {
 
 func intDefault(val, fallback int) int {
 	if val == 0 {
+		return fallback
+	}
+	return val
+}
+
+func positiveIntDefault(val, fallback int) int {
+	if val <= 0 {
 		return fallback
 	}
 	return val

--- a/internal/mcpserver/tools_mutation.go
+++ b/internal/mcpserver/tools_mutation.go
@@ -4,6 +4,8 @@ package mcpserver
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/skaphos/repokeeper/internal/config"
 	"github.com/skaphos/repokeeper/internal/engine"
 	"github.com/skaphos/repokeeper/internal/model"
+	"github.com/skaphos/repokeeper/internal/registry"
 	"github.com/skaphos/repokeeper/internal/sortutil"
 )
 
@@ -49,10 +52,7 @@ func (s *MCPServer) handleScanWorkspace(ctx context.Context, req mcp.CallToolReq
 	}
 
 	reg := s.engine.Registry()
-	prevCount := 0
-	if reg != nil {
-		prevCount = len(reg.Entries)
-	}
+	previousEntries := registryEntrySet(reg)
 
 	statuses, err := s.engine.Scan(ctx, engine.ScanOptions{
 		Roots:   scanRoots,
@@ -80,18 +80,13 @@ func (s *MCPServer) handleScanWorkspace(ctx context.Context, req mcp.CallToolReq
 		return newToolErrorf("scan succeeded but failed to save: %w", err), nil
 	}
 
-	newCount := 0
-	if reg != nil && len(reg.Entries) > prevCount {
-		newCount = len(reg.Entries) - prevCount
-	}
-
-	missing := 0
+	newCount := countNewRegistryEntries(previousEntries, reg)
+	missing := countRegistryEntriesWithStatus(reg, registry.StatusMissing)
 	repos := make([]scanRepoEntry, 0, len(statuses))
 	for _, st := range statuses {
 		status := "present"
 		if st.Error != "" {
 			status = "error"
-			missing++
 		}
 		repos = append(repos, scanRepoEntry{
 			RepoID: st.RepoID,
@@ -108,6 +103,48 @@ func (s *MCPServer) handleScanWorkspace(ctx context.Context, req mcp.CallToolReq
 		Repos:      repos,
 	}
 	return mcp.NewToolResultJSON(resp)
+}
+
+func registryEntrySet(reg *registry.Registry) map[string]struct{} {
+	entries := make(map[string]struct{})
+	if reg == nil {
+		return entries
+	}
+	for _, entry := range reg.Entries {
+		entries[registryEntryKey(entry)] = struct{}{}
+	}
+	return entries
+}
+
+func countNewRegistryEntries(previous map[string]struct{}, reg *registry.Registry) int {
+	count := 0
+	for key := range registryEntrySet(reg) {
+		if _, existed := previous[key]; !existed {
+			count++
+		}
+	}
+	return count
+}
+
+func countRegistryEntriesWithStatus(reg *registry.Registry, status registry.EntryStatus) int {
+	if reg == nil {
+		return 0
+	}
+	count := 0
+	for _, entry := range reg.Entries {
+		if entry.Status == status {
+			count++
+		}
+	}
+	return count
+}
+
+func registryEntryKey(entry registry.Entry) string {
+	checkoutID := strings.TrimSpace(entry.CheckoutID)
+	if checkoutID == "" {
+		checkoutID = filepath.Clean(entry.Path)
+	}
+	return entry.RepoID + "\x00" + checkoutID
 }
 
 // --- plan_sync ---
@@ -336,15 +373,14 @@ func (s *MCPServer) handleRemoveRepository(ctx context.Context, req mcp.CallTool
 		}
 	}
 
-	// Resolve through resolveRepo so an absolute checkout path works (the
-	// schema advertises "repo_id or absolute path"). DeleteRepo itself only
-	// matches by repo_id, so we hand it the resolved entry's RepoID.
+	// Resolve through resolveRepo so an absolute checkout path or checkout_id
+	// identifies one entry before the engine performs the mutation.
 	entry, err := resolveRepo(s.engine.Registry(), repoArg)
 	if err != nil {
 		return newToolError(err), nil
 	}
 
-	if err := s.engine.DeleteRepo(ctx, entry.RepoID, s.cfgPath, deleteFiles); err != nil {
+	if err := s.engine.DeleteRepo(ctx, entry.Path, s.cfgPath, deleteFiles); err != nil {
 		return newToolError(err), nil
 	}
 
@@ -461,6 +497,14 @@ func (s *MCPServer) saveConfig() error {
 	if cfg == nil {
 		return nil
 	}
+	if fresh, err := config.Load(s.cfgPath); err == nil {
+		cfg = fresh
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	cfg.Registry = s.engine.Registry()
-	return config.Save(cfg, s.cfgPath)
+	if err := config.Save(cfg, s.cfgPath); err != nil {
+		return err
+	}
+	return s.engine.ReloadConfig(s.cfgPath)
 }


### PR DESCRIPTION
## Summary

- resolve MCP repository selectors in exact path, checkout ID, then repository ID order, and pass the selected checkout through deletion
- calculate scan additions independently from pruning and report the registry's current missing-entry count
- reload MCP config and registry state for every request, preserving live on-disk config fields when registry mutations are saved
- expose and document `registry_stale_days`, selector behavior, and nested worktree discovery behavior

## Adversarial review

- reject duplicate exact paths and checkout IDs instead of selecting an arbitrary entry
- treat only absolute selectors as paths, preventing collisions with checkout IDs or repository IDs
- validate destructive filesystem targets before removing their registry entry
- fail closed when a live reload no longer contains a registry
- no unresolved security findings in the changed code

## Testing

- `go -C tools tool task -d .. ci`
- `GOCACHE=/tmp/repokeeper-gocache go test -race ./internal/engine ./internal/mcpserver`
- `go vet ./...`
- `go run github.com/securego/gosec/v2/cmd/gosec@v2.22.10 -quiet ./internal/engine/... ./internal/mcpserver/...` (no new findings; one existing G301 in `internal/engine/import_clone.go`)

Closes #318
Closes #319
Closes #320

Signed-off-by: Shawn Stratton <shawn@skaphos.io>
