### PR TITLE
fix(security): restrict import directory permissions

### DIFF
--- a/internal/engine/engine_actions_import_repair_internal_test.go
+++ b/internal/engine/engine_actions_import_repair_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -143,6 +144,39 @@ func TestPlanImportClonesSkipsAndSuccess(t *testing.T) {
 }
 
 func TestExecuteImportClonesSuccessFailureAndSkips(t *testing.T) {
+	t.Run("creates clone parent without permissions for other users", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows does not preserve Unix permission bits")
+		}
+
+		parentPath := filepath.Join(t.TempDir(), "repos")
+		targetPath := filepath.Join(parentPath, "repo")
+		eng := &Engine{
+			registry:   &registry.Registry{},
+			adapter:    &planAdapter{cloneErrByDir: map[string]error{}},
+			classifier: vcs.NewGitErrorClassifier(),
+		}
+		plan := ImportClonePlan{Clones: []ImportCloneTarget{{
+			Path: targetPath,
+			Entry: registry.Entry{
+				RepoID:    "repo",
+				RemoteURL: "git@github.com:org/repo.git",
+				Branch:    "main",
+			},
+		}}}
+
+		if _, err := eng.ExecuteImportClones(context.Background(), plan, ImportCloneCallbacks{}); err != nil {
+			t.Fatalf("execute import clones: %v", err)
+		}
+		info, err := os.Stat(parentPath)
+		if err != nil {
+			t.Fatalf("stat clone parent: %v", err)
+		}
+		if got := info.Mode().Perm(); got&0o007 != 0 {
+			t.Fatalf("expected clone parent to deny permissions to other users, got %04o", got)
+		}
+	})
+
 	t.Run("successful clone with dangerous delete updates registry and callbacks", func(t *testing.T) {
 		cwd := t.TempDir()
 		targetPath := filepath.Join(cwd, "repos", "repo")

--- a/internal/engine/import_clone.go
+++ b/internal/engine/import_clone.go
@@ -153,7 +153,7 @@ func (e *Engine) ExecuteImportClones(ctx context.Context, plan ImportClonePlan, 
 		if callbacks.OnStart != nil {
 			callbacks.OnStart(result)
 		}
-		if err := os.MkdirAll(filepath.Dir(target.Path), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(target.Path), 0o750); err != nil {
 			return failures, err
 		}
 		if _, err := os.Stat(target.Path); err == nil {


### PR DESCRIPTION
## Summary

- create import clone parent directories with mode 0750 instead of 0755
- add a Unix regression test that verifies newly created parents grant no permissions to other users

## Security rationale

The import destination is normally below the user home directory, but an explicit 0750 mode is a defensible least-privilege default independent of the enclosing directory mode. It preserves owner access and group traversal while removing global read and traversal access, resolving gosec G301.

## Testing

- GOCACHE=/tmp/repokeeper-gocache go test ./internal/engine
- GOCACHE=/tmp/repokeeper-gocache go run github.com/securego/gosec/v2/cmd/gosec@v2.22.10 -quiet -fmt=text ./internal/engine/... (zero findings)
- GOCACHE=/tmp/repokeeper-gocache go -C tools tool task -d .. ci
- graphify update .