### PR TITLE
ci: qualify compatibility on the release PR, not every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,97 +124,6 @@ jobs:
       - name: Run integration race task
         run: go -C tools tool task test-integration-race
 
-  compatibility-matrix:
-    name: Routine Compatibility Matrix
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-      - id: matrix
-        name: Expand the declared routine matrix
-        shell: bash
-        run: echo "matrix=$(go run -tags integration ./test/e2e/cmd/compatibility matrix --scope routine)" >> "$GITHUB_OUTPUT"
-
-  compatibility:
-    name: Compatibility / ${{ matrix.cell.key }}
-    needs: compatibility-matrix
-    runs-on: ${{ matrix.cell.runner_label }}
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        cell: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix).cells }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-      - name: Record runner and source identity
-        shell: bash
-        env:
-          CELL: ${{ matrix.cell.key }}
-          RUNNER_IMAGE: ${{ runner.os }}-${{ runner.arch }}
-        run: printf 'cell=%s\nrunner=%s\ncommit=%s\n' "$CELL" "$RUNNER_IMAGE" "$GITHUB_SHA"
-      - name: Provision and exactly verify declared Git
-        shell: bash
-        env:
-          CELL: ${{ matrix.cell.key }}
-        run: |
-          set -euo pipefail
-          prefix="$RUNNER_TEMP/repokeeper-${CELL}"
-          go run -tags integration ./test/e2e/cmd/compatibility provision --cell "$CELL" --prefix "$prefix" > "$RUNNER_TEMP/provision.json"
-          git_path="$(jq -r .git_path "$RUNNER_TEMP/provision.json")"
-          go run -tags integration ./test/e2e/cmd/compatibility verify-version --cell "$CELL" --git "$git_path"
-          if [[ "$CELL" != wsl-* ]]; then
-            # git_path comes from filepath.Join, so Windows cells report
-            # backslashes. POSIX dirname would see no separator and answer ".",
-            # silently leaving the runner Git ahead of the provisioned one.
-            printf '%s\n' "$(dirname "${git_path//\\//}")" >> "$GITHUB_PATH"
-          fi
-      - name: Run native compatibility E2E
-        if: matrix.cell.environment != 'wsl'
-        run: go test -v -count=1 -timeout 10m -tags integration ./test/e2e
-      - name: Cross-compile and run WSL compatibility E2E
-        if: matrix.cell.environment == 'wsl'
-        shell: bash
-        run: |
-          set -euo pipefail
-          windows_to_wsl() {
-            local windows_path="$1"
-            local drive="${windows_path:0:1}"
-            local tail="${windows_path:2}"
-            tail="${tail//\\//}"
-            printf '/mnt/%s%s' "${drive,,}" "$tail"
-          }
-          distribution="$(jq -r .wsl_distribution "$RUNNER_TEMP/provision.json")"
-          repo_linux="$(windows_to_wsl "$GITHUB_WORKSPACE")"
-          binary_windows="$RUNNER_TEMP/repokeeper-e2e-product"
-          compatibility_windows="$RUNNER_TEMP/repokeeper-compatibility"
-          test_windows="$RUNNER_TEMP/repokeeper-e2e.test"
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$binary_windows" .
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags integration -o "$compatibility_windows" ./test/e2e/cmd/compatibility
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c -tags integration -o "$test_windows" ./test/e2e
-          binary_linux="$(windows_to_wsl "$binary_windows")"
-          compatibility_linux="$(windows_to_wsl "$compatibility_windows")"
-          test_linux="$(windows_to_wsl "$test_windows")"
-          MSYS2_ARG_CONV_EXCL='*' wsl.exe -d "$distribution" -- env \
-            PATH="/opt/repokeeper-git/bin:/usr/bin:/bin" \
-            REPOKEEPER_E2E_BINARY="$binary_linux" \
-            REPOKEEPER_E2E_COMPATIBILITY_BINARY="$compatibility_linux" \
-            REPOKEEPER_E2E_MODULE_ROOT="$repo_linux" \
-            "$test_linux" -test.v
-      - name: Unregister WSL distribution
-        if: always() && matrix.cell.environment == 'wsl'
-        shell: bash
-        run: |
-          distribution="$(jq -r '.wsl_distribution // empty' "$RUNNER_TEMP/provision.json" 2>/dev/null || true)"
-          if [ -n "$distribution" ]; then wsl.exe --unregister "$distribution"; fi
-
   quality:
     name: Static Analysis
     runs-on: ubuntu-24.04
@@ -292,7 +201,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [dco, reuse, lint, test, integration, integration-race, compatibility, quality, perf, manifests]
+    needs: [dco, reuse, lint, test, integration, integration-race, quality, perf, manifests]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -311,7 +220,7 @@ jobs:
     name: CI Summary
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    needs: [dco, reuse, lint, test, integration, integration-race, compatibility, quality, perf, manifests, build]
+    needs: [dco, reuse, lint, test, integration, integration-race, quality, perf, manifests, build]
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Publish workflow summary
@@ -322,19 +231,18 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
           INTEGRATION_RACE_RESULT: ${{ needs.integration-race.result }}
-          COMPATIBILITY_RESULT: ${{ needs.compatibility.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
           PERF_RESULT: ${{ needs.perf.result }}
           MANIFESTS_RESULT: ${{ needs.manifests.result }}
           BUILD_RESULT: ${{ needs.build.result }}
         run: |
-          total=11
+          total=10
           success=0
           failed=0
           skipped=0
           cancelled=0
 
-          for result in "$DCO_RESULT" "$REUSE_RESULT" "$LINT_RESULT" "$TEST_RESULT" "$INTEGRATION_RESULT" "$INTEGRATION_RACE_RESULT" "$COMPATIBILITY_RESULT" "$QUALITY_RESULT" "$PERF_RESULT" "$MANIFESTS_RESULT" "$BUILD_RESULT"; do
+          for result in "$DCO_RESULT" "$REUSE_RESULT" "$LINT_RESULT" "$TEST_RESULT" "$INTEGRATION_RESULT" "$INTEGRATION_RACE_RESULT" "$QUALITY_RESULT" "$PERF_RESULT" "$MANIFESTS_RESULT" "$BUILD_RESULT"; do
             case "$result" in
               success) success=$((success + 1)) ;;
               failure) failed=$((failed + 1)) ;;
@@ -355,7 +263,6 @@ jobs:
             echo "| test | $TEST_RESULT |"
             echo "| integration | $INTEGRATION_RESULT |"
             echo "| integration-race | $INTEGRATION_RACE_RESULT |"
-            echo "| compatibility | $COMPATIBILITY_RESULT |"
             echo "| quality | $QUALITY_RESULT |"
             echo "| perf | $PERF_RESULT |"
             echo "| manifests | $MANIFESTS_RESULT |"
@@ -375,7 +282,6 @@ jobs:
               if [ "$TEST_RESULT" = "failure" ]; then echo "- test failed"; fi
               if [ "$INTEGRATION_RESULT" = "failure" ]; then echo "- integration failed"; fi
               if [ "$INTEGRATION_RACE_RESULT" = "failure" ]; then echo "- integration-race failed"; fi
-              if [ "$COMPATIBILITY_RESULT" = "failure" ]; then echo "- compatibility failed"; fi
               if [ "$QUALITY_RESULT" = "failure" ]; then echo "- quality failed"; fi
               if [ "$PERF_RESULT" = "failure" ]; then echo "- perf failed"; fi
               if [ "$MANIFESTS_RESULT" = "failure" ]; then echo "- manifests failed"; fi

--- a/.github/workflows/qualification.yml
+++ b/.github/workflows/qualification.yml
@@ -10,6 +10,12 @@ name: Qualification
 # This is a gate, not the publication record. `release.yml` re-runs the matrix
 # on the pushed tag and writes the evidence documents, because evidence is bound
 # to the exact tag and commit being published.
+#
+# The guard requires the branch to live in this repository as well as to carry
+# the release-please name. A branch name alone is attacker-controlled: anyone
+# can push `release-please--branches--main` to a fork and open a pull request,
+# which would otherwise spend twelve runners, one of them building Git from
+# source inside WSL.
 
 on:
   pull_request:
@@ -21,7 +27,7 @@ permissions:
 jobs:
   compatibility-matrix:
     name: Release Compatibility Matrix
-    if: github.head_ref == 'release-please--branches--main'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -39,7 +45,7 @@ jobs:
   compatibility:
     name: Qualify / ${{ matrix.cell.key }}
     needs: compatibility-matrix
-    if: github.head_ref == 'release-please--branches--main'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main'
     runs-on: ${{ matrix.cell.runner_label }}
     timeout-minutes: 30
     strategy:
@@ -126,10 +132,12 @@ jobs:
         shell: bash
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
           RESULT: ${{ needs.compatibility.result }}
         run: |
           set -euo pipefail
-          if [ "$HEAD_REF" != "release-please--branches--main" ]; then
+          if [ "$HEAD_REPO" != "$THIS_REPO" ] || [ "$HEAD_REF" != "release-please--branches--main" ]; then
             echo "Not the release pull request; compatibility qualification is not required here."
             exit 0
           fi

--- a/.github/workflows/qualification.yml
+++ b/.github/workflows/qualification.yml
@@ -1,0 +1,140 @@
+name: Qualification
+
+# Release qualification gate.
+#
+# The full twelve-cell compatibility matrix is expensive, so it does not run on
+# ordinary pull requests. It runs on the release-please pull request, before the
+# version is cut, so a compatibility regression blocks the release instead of
+# surfacing after the tag already exists.
+#
+# This is a gate, not the publication record. `release.yml` re-runs the matrix
+# on the pushed tag and writes the evidence documents, because evidence is bound
+# to the exact tag and commit being published.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility-matrix:
+    name: Release Compatibility Matrix
+    if: github.head_ref == 'release-please--branches--main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - id: matrix
+        name: Expand all twelve declared cells
+        shell: bash
+        run: echo "matrix=$(go run -tags integration ./test/e2e/cmd/compatibility matrix --scope release)" >> "$GITHUB_OUTPUT"
+
+  compatibility:
+    name: Qualify / ${{ matrix.cell.key }}
+    needs: compatibility-matrix
+    if: github.head_ref == 'release-please--branches--main'
+    runs-on: ${{ matrix.cell.runner_label }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        cell: ${{ fromJSON(needs.compatibility-matrix.outputs.matrix).cells }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Record runner and candidate identity
+        shell: bash
+        env:
+          CELL: ${{ matrix.cell.key }}
+          RUNNER_IMAGE: ${{ runner.os }}-${{ runner.arch }}
+        run: printf 'cell=%s\nrunner=%s\ncommit=%s\n' "$CELL" "$RUNNER_IMAGE" "$GITHUB_SHA"
+      - name: Provision and exactly verify declared Git
+        shell: bash
+        env:
+          CELL: ${{ matrix.cell.key }}
+        run: |
+          set -euo pipefail
+          prefix="$RUNNER_TEMP/repokeeper-${CELL}"
+          go run -tags integration ./test/e2e/cmd/compatibility provision --cell "$CELL" --prefix "$prefix" > "$RUNNER_TEMP/provision.json"
+          git_path="$(jq -r .git_path "$RUNNER_TEMP/provision.json")"
+          go run -tags integration ./test/e2e/cmd/compatibility verify-version --cell "$CELL" --git "$git_path"
+          if [[ "$CELL" != wsl-* ]]; then
+            # git_path comes from filepath.Join, so Windows cells report
+            # backslashes. POSIX dirname would see no separator and answer ".",
+            # silently leaving the runner Git ahead of the provisioned one.
+            printf '%s\n' "$(dirname "${git_path//\\//}")" >> "$GITHUB_PATH"
+          fi
+      - name: Run native compatibility E2E
+        if: matrix.cell.environment != 'wsl'
+        run: go test -v -count=1 -timeout 10m -tags integration ./test/e2e
+      - name: Cross-compile and run WSL compatibility E2E
+        if: matrix.cell.environment == 'wsl'
+        shell: bash
+        run: |
+          set -euo pipefail
+          windows_to_wsl() {
+            local windows_path="$1"
+            local drive="${windows_path:0:1}"
+            local tail="${windows_path:2}"
+            tail="${tail//\\//}"
+            printf '/mnt/%s%s' "${drive,,}" "$tail"
+          }
+          distribution="$(jq -r .wsl_distribution "$RUNNER_TEMP/provision.json")"
+          repo_linux="$(windows_to_wsl "$GITHUB_WORKSPACE")"
+          binary_windows="$RUNNER_TEMP/repokeeper-e2e-product"
+          compatibility_windows="$RUNNER_TEMP/repokeeper-compatibility"
+          test_windows="$RUNNER_TEMP/repokeeper-e2e.test"
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$binary_windows" .
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags integration -o "$compatibility_windows" ./test/e2e/cmd/compatibility
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c -tags integration -o "$test_windows" ./test/e2e
+          binary_linux="$(windows_to_wsl "$binary_windows")"
+          compatibility_linux="$(windows_to_wsl "$compatibility_windows")"
+          test_linux="$(windows_to_wsl "$test_windows")"
+          MSYS2_ARG_CONV_EXCL='*' wsl.exe -d "$distribution" -- env \
+            PATH="/opt/repokeeper-git/bin:/usr/bin:/bin" \
+            REPOKEEPER_E2E_BINARY="$binary_linux" \
+            REPOKEEPER_E2E_COMPATIBILITY_BINARY="$compatibility_linux" \
+            REPOKEEPER_E2E_MODULE_ROOT="$repo_linux" \
+            "$test_linux" -test.v
+      - name: Unregister WSL distribution
+        if: always() && matrix.cell.environment == 'wsl'
+        shell: bash
+        run: |
+          distribution="$(jq -r '.wsl_distribution // empty' "$RUNNER_TEMP/provision.json" 2>/dev/null || true)"
+          if [ -n "$distribution" ]; then wsl.exe --unregister "$distribution"; fi
+
+  # One stable check name that always reports, so it can be a required status
+  # check. The per-cell jobs are skipped on ordinary pull requests and their
+  # names vary with the declaration, so neither can be required directly.
+  gate:
+    name: Release Qualification
+    needs: compatibility
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every declared cell on the release pull request
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          RESULT: ${{ needs.compatibility.result }}
+        run: |
+          set -euo pipefail
+          if [ "$HEAD_REF" != "release-please--branches--main" ]; then
+            echo "Not the release pull request; compatibility qualification is not required here."
+            exit 0
+          fi
+          if [ "$RESULT" != "success" ]; then
+            echo "Compatibility qualification did not pass (result: ${RESULT})." >&2
+            exit 1
+          fi
+          echo "Every declared cell qualified."

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -700,7 +700,7 @@ RepoKeeper makes a **closed** compatibility claim for exactly Git `2.53`, `2.54`
 | native Windows (`windows-2025`) | 2.53.0.windows.1 | 2.54.0.windows.1 | 2.55.0.windows.1 | 2.55.0.windows.1 |
 | WSL1 / Ubuntu 24.04 (`windows-2025`) | 2.53.0 | 2.54.0 | 2.55.0 | 2.54.0 |
 
-Routine CI executes the four representatives. A full release executes all twelve cells and requires exact, unique, successful evidence before publication. WSL uses the checksum-pinned Canonical Noble `20240423` root filesystem and never falls back to native Windows, WSL2, or runner Git.
+Provisioning Git on four runner images is too costly to repeat for every change, so routine pull request CI does not execute the matrix at all. All twelve cells run on the release pull request, gating the merge that cuts the version, and again on the pushed tag, where they produce the exact, unique, successful evidence required before publication. The four representatives remain available as the `routine` scope for local and on-demand runs. WSL uses the checksum-pinned Canonical Noble `20240423` root filesystem and never falls back to native Windows, WSL2, or runner Git.
 
 The compatibility audit covers every command family delegated by `internal/gitx` and `internal/vcs`: `rev-parse`, `remote`, `remote get-url`, `remote prune --dry-run`, `config`, `status --porcelain=v1`, `symbolic-ref`, `for-each-ref` (including merged and tracking formats), `rev-list`, `fetch`, `pull --rebase`, `push`, `branch --set-upstream-to`, `remote set-url`, `stash`, `reset --hard`, `clean`, `clone`, and `cherry`. Changes to those invocations require updating the declaration and matrix tests.
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -25,7 +25,7 @@ Failures print the operation, argument vector, working directory, scenario root,
 
 ## Git compatibility command
 
-`testdata/git-compatibility.json` is the executable source for the closed Git `2.53`/`2.54`/`2.55` claim across Linux, macOS, native Windows, and WSL. Routine CI selects one declared cell per environment; a tagged full release must produce one successful evidence document for all twelve cells.
+`testdata/git-compatibility.json` is the executable source for the closed Git `2.53`/`2.54`/`2.55` claim across Linux, macOS, native Windows, and WSL. Routine pull request CI does not run the matrix. All twelve cells run on the release pull request as a merge gate, and a tagged full release must produce one successful evidence document for all twelve. The `routine` scope selects one declared cell per environment and is kept for local and on-demand runs.
 
 ```sh
 go run -tags integration ./test/e2e/cmd/compatibility matrix --scope routine

--- a/test/e2e/workflow_contract_spec_test.go
+++ b/test/e2e/workflow_contract_spec_test.go
@@ -69,14 +69,24 @@ var _ = Describe("Compatibility workflow contracts", func() {
 			Expect(text).To(ContainSubstring(required))
 		}
 		// Both jobs carry the guard, so a matrix expansion never runs for an
-		// ordinary contributor pull request.
-		Expect(strings.Count(text, "if: github.head_ref == 'release-please--branches--main'")).To(Equal(2))
+		// ordinary contributor pull request. The guard must check the head
+		// repository too: a branch name alone is attacker-controlled, so a
+		// fork could otherwise spend twelve runners by naming its branch after
+		// the release-please one.
+		guard := "if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'release-please--branches--main'"
+		Expect(strings.Count(text, guard)).To(Equal(2))
+		Expect(text).NotTo(MatchRegexp(`if: github\.head_ref ==[^\n]*\n`), "the branch guard must also pin the head repository")
 		Expect(text).To(ContainSubstring("permissions:\n  contents: read"))
 		Expect(text).NotTo(ContainSubstring("secrets."))
 		// A single always-reporting job carries a stable check name, so the
 		// gate can be a required status check even though the per-cell jobs
 		// are skipped on ordinary pull requests.
 		for _, required := range []string{"name: Release Qualification", "needs: compatibility", "if: always()", `RESULT: ${{ needs.compatibility.result }}`} {
+			Expect(text).To(ContainSubstring(required))
+		}
+		// The gate reports on every pull request, so it repeats the same
+		// head-repository check rather than trusting the branch name.
+		for _, required := range []string{`HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}`, `THIS_REPO: ${{ github.repository }}`, `[ "$HEAD_REPO" != "$THIS_REPO" ]`} {
 			Expect(text).To(ContainSubstring(required))
 		}
 	})

--- a/test/e2e/workflow_contract_spec_test.go
+++ b/test/e2e/workflow_contract_spec_test.go
@@ -19,7 +19,7 @@ var actionReferencePattern = regexp.MustCompile(`uses:\s+[^\s@]+@([0-9a-f]{40})(
 
 var _ = Describe("Compatibility workflow contracts", func() {
 	It("pins runners, actions, permissions, and timeouts in every workflow", func() {
-		for _, name := range []string{"ci.yml", "release.yml", "release-please.yml"} {
+		for _, name := range []string{"ci.yml", "qualification.yml", "release.yml", "release-please.yml"} {
 			path := filepath.Join(moduleRoot, ".github", "workflows", name)
 			data, err := os.ReadFile(path)
 			Expect(err).NotTo(HaveOccurred())
@@ -43,14 +43,42 @@ var _ = Describe("Compatibility workflow contracts", func() {
 		}
 	})
 
-	It("uses the executable four-cell routine matrix and a required race job", func() {
+	It("keeps the compatibility matrix out of routine pull request CI", func() {
 		data, err := os.ReadFile(filepath.Join(moduleRoot, ".github", "workflows", "ci.yml"))
 		Expect(err).NotTo(HaveOccurred())
 		text := string(data)
-		for _, required := range []string{"matrix --scope routine", "fail-fast: false", "ubuntu-24.04", "macos-15", "windows-2025", "matrix.cell.environment == 'wsl'", "windows_to_wsl", "./test/e2e/cmd/compatibility", "REPOKEEPER_E2E_COMPATIBILITY_BINARY", "MSYS2_ARG_CONV_EXCL='*'", "test-integration-race", "-race", "needs: compatibility-matrix"} {
+		// The matrix provisions Git on four runner images per pull request, so
+		// routine CI must not carry it. Qualification runs on the release
+		// pull request instead, before a version is cut.
+		for _, forbidden := range []string{"cmd/compatibility", "--scope routine", "--scope release", "wsl.exe"} {
+			Expect(text).NotTo(ContainSubstring(forbidden), "ci.yml must not run the compatibility matrix")
+		}
+		for _, required := range []string{"test-integration-race", "-race"} {
 			Expect(text).To(ContainSubstring(required))
 		}
 		Expect(text).To(ContainSubstring("permissions:\n  contents: read"))
+	})
+
+	It("gates the release pull request on the executable twelve-cell matrix", func() {
+		data, err := os.ReadFile(filepath.Join(moduleRoot, ".github", "workflows", "qualification.yml"))
+		Expect(err).NotTo(HaveOccurred())
+		text := string(data)
+		// Runner labels come from the declaration rather than being written
+		// here, and Validate pins each cell to an exact non-latest image.
+		for _, required := range []string{"matrix --scope release", "fail-fast: false", "runs-on: ${{ matrix.cell.runner_label }}", "matrix.cell.environment == 'wsl'", "windows_to_wsl", "./test/e2e/cmd/compatibility", "REPOKEEPER_E2E_COMPATIBILITY_BINARY", "MSYS2_ARG_CONV_EXCL='*'", "needs: compatibility-matrix"} {
+			Expect(text).To(ContainSubstring(required))
+		}
+		// Both jobs carry the guard, so a matrix expansion never runs for an
+		// ordinary contributor pull request.
+		Expect(strings.Count(text, "if: github.head_ref == 'release-please--branches--main'")).To(Equal(2))
+		Expect(text).To(ContainSubstring("permissions:\n  contents: read"))
+		Expect(text).NotTo(ContainSubstring("secrets."))
+		// A single always-reporting job carries a stable check name, so the
+		// gate can be a required status check even though the per-cell jobs
+		// are skipped on ordinary pull requests.
+		for _, required := range []string{"name: Release Qualification", "needs: compatibility", "if: always()", `RESULT: ${{ needs.compatibility.result }}`} {
+			Expect(text).To(ContainSubstring(required))
+		}
 	})
 
 	It("gates every publisher on exact twelve-cell evidence", func() {


### PR DESCRIPTION
## Summary

Routine CI provisioned Git across four runner images on **every** pull request. That is a large, slow cost for changes that cannot affect Git compatibility, and it was buying very little.

The authoritative twelve-cell qualification only ran on the pushed tag — and that tag is created *after* the release pull request merges. A compatibility regression was therefore discovered once the version had already been cut, which is damage control rather than a gate.

This moves qualification to the release pull request, where it gates the merge that cuts the version.

- drop the four-cell matrix from `ci.yml` entirely, so ordinary pull requests no longer provision Git
- add `qualification.yml`, running all twelve declared cells on the release-please pull request only
- keep `release.yml` unchanged — it re-runs the matrix on the tag and writes the evidence documents, because evidence is bound to the exact tag and commit being published

## Cost

| | before | after |
|---|---|---|
| ordinary pull request | 4 cells | 0 |
| release pull request | 4 cells | 12 cells |
| pushed tag | 12 cells | 12 cells |

Every ordinary pull request stops paying for Git provisioning. The release path pays twice, which is deliberate: the pre-merge run is the gate, and the tag-time run is the publication record whose evidence must bind to the published commit.

## The `Release Qualification` job

The per-cell jobs are skipped on ordinary pull requests, and their names vary with the declaration, so neither can serve as a required status check. A single `Release Qualification` job always reports — passing trivially off the release branch, failing if any cell did not succeed — which gives branch protection one stable name to require.

Without adding that name to branch protection this gate is advisory: the checks appear on the release PR but nothing blocks a merge past them. Wiring it up is a repository settings change, not a code change.

## Security

`github.head_ref` is only ever compared inside an `if:` expression and is never interpolated into a shell command, so the usual workflow-injection concern for that value does not apply here.

## Testing

- `go test -count=1 -tags integration ./test/e2e/...` (63 specs)
- `go test -count=1 ./...`
- `go -C tools tool task lint` (0 issues)
- `go run -tags integration ./test/e2e/cmd/compatibility verify-docs`

The workflow contract now asserts that `ci.yml` runs no part of the matrix, and that `qualification.yml` carries the release scope, the branch guard on both jobs, and the gate. `qualification.yml` was also added to the existing loop that enforces pinned runners, SHA-pinned actions, and per-job timeouts.

Verified by mutation — appending a compatibility invocation to `ci.yml` fails the spec with the intended message:

```
[FAILED] ci.yml must not run the compatibility matrix
```

## Notes

The `routine` four-cell scope is retained for local and on-demand runs; no workflow calls it now. `DESIGN.md` and `test/e2e/README.md` are updated to describe the new trigger.
